### PR TITLE
Make daily usage screen accessible

### DIFF
--- a/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/navigation/AppNavHost.kt
+++ b/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/navigation/AppNavHost.kt
@@ -12,6 +12,7 @@ import co.ke.foxlysoft.budgetgain.ui.AddCategoryScreen
 import co.ke.foxlysoft.budgetgain.ui.AllBudgetsScreen
 import co.ke.foxlysoft.budgetgain.ui.CategoryDetailsScreen
 import co.ke.foxlysoft.budgetgain.ui.CreateBudgetScreen
+import co.ke.foxlysoft.budgetgain.ui.DailyUsageScreen
 import co.ke.foxlysoft.budgetgain.ui.EditCategoryScreen
 import co.ke.foxlysoft.budgetgain.ui.HomeScreen
 import co.ke.foxlysoft.budgetgain.ui.MerchantTransactionsScreen
@@ -162,12 +163,7 @@ fun AppNavHost(
         animatedComposable(
             Screens.DailyUsage.route,
         ) {
-            UncategorizedMpesaSmsScreen(
-                onNavigate = {route ->
-                    navHostController.navigate(route)
-                },
-                onOpenSnackbar = onOpenSnackbar
-            )
+            DailyUsageScreen()
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/ui/DailyUsageScreen.kt
+++ b/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/ui/DailyUsageScreen.kt
@@ -36,11 +36,11 @@ import androidx.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
-fun CreateBudgetScreen(
+fun DailyUsageScreen(
     dailyUsageScreenViewModel: DailyUsageScreenViewModel = koinViewModel(),
 ) {
     val dayStatus = mutableMapOf<LocalDate, DayStatus>()
-    CreateBudgetScreenContent(dayStatus)
+    DailyUsageScreenContent(dayStatus)
 }
 
 data class RemainingBudget (
@@ -50,7 +50,7 @@ data class RemainingBudget (
 )
 
 @Composable
-fun CreateBudgetScreenContent(dayStatus: Map<LocalDate, DayStatus>) {
+fun DailyUsageScreenContent(dayStatus: Map<LocalDate, DayStatus>) {
     val remainingBudges = listOf(
         RemainingBudget("Daily", 1000),
         RemainingBudget("Weekly", 1000),
@@ -124,11 +124,11 @@ fun CreateBudgetScreenContent(dayStatus: Map<LocalDate, DayStatus>) {
 
 @Preview
 @Composable
-fun CreateBudgetScreenPreview() {
+fun DailyUsageScreenPreview() {
     val dayStatus = mutableMapOf<LocalDate, DayStatus>()
     BudgetGainTheme {
         Surface {
-            CreateBudgetScreenContent(dayStatus)
+            DailyUsageScreenContent(dayStatus)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/ui/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/ui/HomeScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.BarChart
 import androidx.compose.material.icons.filled.Category
+import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.Button
@@ -258,6 +259,13 @@ fun HomeContent(
                             modifier = Modifier.height(30.dp)
                         )
                         Spacer(modifier = Modifier.weight(1f))
+                        TextButton(onClick = { onNavigate(Screens.DailyUsage.route) }) {
+                            Icon(
+                                imageVector = Icons.Default.CalendarMonth,
+                                contentDescription = "Daily usage"
+                            )
+                            Text("Daily")
+                        }
                         Text(text = "Bal: ")
                         Text(centsToString(currentBudget.budgetedAmount - currentBudget.spentAmount),
                             style = MaterialTheme.typography.titleMedium


### PR DESCRIPTION
## Summary

- Add a Daily button to the Home screen
- Open the Daily Usage screen from its navigation route
- Rename daily usage composables to match their purpose

## Testing

- `./gradlew :composeApp:compileDebugKotlinAndroid`