### PR TITLE
Add common categories and category UX

### DIFF
--- a/composeApp/schemas/co.ke.foxlysoft.budgetgain.database.AppDatabase/19.json
+++ b/composeApp/schemas/co.ke.foxlysoft.budgetgain.database.AppDatabase/19.json
@@ -1,0 +1,574 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 19,
+    "identityHash": "82b68e13a83a12b21dd49dccb4558068",
+    "entities": [
+      {
+        "tableName": "UserEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `username` TEXT NOT NULL, `password` TEXT NOT NULL, `createdAt` TEXT NOT NULL, `updatedAt` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "password",
+            "columnName": "password",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "SettingsEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`settingKey` TEXT NOT NULL, `value` TEXT NOT NULL, PRIMARY KEY(`settingKey`))",
+        "fields": [
+          {
+            "fieldPath": "settingKey",
+            "columnName": "settingKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "settingKey"
+          ]
+        }
+      },
+      {
+        "tableName": "BudgetEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `yearMonth` TEXT NOT NULL, `isActive` INTEGER NOT NULL, `initialBalance` INTEGER NOT NULL, `budgetedAmount` INTEGER NOT NULL, `spentAmount` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "yearMonth",
+            "columnName": "yearMonth",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isActive",
+            "columnName": "isActive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "initialBalance",
+            "columnName": "initialBalance",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetedAmount",
+            "columnName": "budgetedAmount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spentAmount",
+            "columnName": "spentAmount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "CategoryEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `budgetId` INTEGER NOT NULL, `name` TEXT NOT NULL, `amount` INTEGER NOT NULL, `spentAmount` INTEGER NOT NULL, `trackMode` TEXT, `catalogKey` TEXT, `lightColorArgb` INTEGER NOT NULL, `darkColorArgb` INTEGER NOT NULL, `iconKey` TEXT NOT NULL, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetId",
+            "columnName": "budgetId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "spentAmount",
+            "columnName": "spentAmount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackMode",
+            "columnName": "trackMode",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "catalogKey",
+            "columnName": "catalogKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lightColorArgb",
+            "columnName": "lightColorArgb",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "darkColorArgb",
+            "columnName": "darkColorArgb",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconKey",
+            "columnName": "iconKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "AccountEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `type` TEXT NOT NULL, `name` TEXT NOT NULL, `holderType` TEXT NOT NULL, `budgetId` INTEGER NOT NULL, `merchantName` TEXT NOT NULL, `merchantIdentifierType` TEXT NOT NULL, `merchantIdentifier` TEXT NOT NULL, `merchantDefaultCategoryId` INTEGER NOT NULL, `balance` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "holderType",
+            "columnName": "holderType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetId",
+            "columnName": "budgetId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantName",
+            "columnName": "merchantName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantIdentifierType",
+            "columnName": "merchantIdentifierType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantIdentifier",
+            "columnName": "merchantIdentifier",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "merchantDefaultCategoryId",
+            "columnName": "merchantDefaultCategoryId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "balance",
+            "columnName": "balance",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "TransactionEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ref` TEXT NOT NULL, `type` TEXT NOT NULL, `description` TEXT NOT NULL, `budgetId` INTEGER NOT NULL, `debitAccountId` INTEGER NOT NULL, `creditAccountId` INTEGER NOT NULL, `categoryId` INTEGER NOT NULL, `subCategoryId` INTEGER, `amount` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `timestamp` TEXT NOT NULL, FOREIGN KEY(`subCategoryId`) REFERENCES `SubCategoryEntity`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ref",
+            "columnName": "ref",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "budgetId",
+            "columnName": "budgetId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "debitAccountId",
+            "columnName": "debitAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "creditAccountId",
+            "columnName": "creditAccountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subCategoryId",
+            "columnName": "subCategoryId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_TransactionEntity_subCategoryId",
+            "unique": false,
+            "columnNames": [
+              "subCategoryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_TransactionEntity_subCategoryId` ON `${TABLE_NAME}` (`subCategoryId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "SubCategoryEntity",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "subCategoryId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "SubCategoryEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `categoryId` INTEGER NOT NULL, `catalogKey` TEXT, `name` TEXT NOT NULL, `iconKey` TEXT, `lightColorArgb` INTEGER, `darkColorArgb` INTEGER, `createdAt` INTEGER NOT NULL, FOREIGN KEY(`categoryId`) REFERENCES `CategoryEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "categoryId",
+            "columnName": "categoryId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "catalogKey",
+            "columnName": "catalogKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iconKey",
+            "columnName": "iconKey",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lightColorArgb",
+            "columnName": "lightColorArgb",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "darkColorArgb",
+            "columnName": "darkColorArgb",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_SubCategoryEntity_categoryId",
+            "unique": false,
+            "columnNames": [
+              "categoryId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_SubCategoryEntity_categoryId` ON `${TABLE_NAME}` (`categoryId`)"
+          },
+          {
+            "name": "index_SubCategoryEntity_categoryId_catalogKey",
+            "unique": true,
+            "columnNames": [
+              "categoryId",
+              "catalogKey"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_SubCategoryEntity_categoryId_catalogKey` ON `${TABLE_NAME}` (`categoryId`, `catalogKey`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "CategoryEntity",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "categoryId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "MpesaSmsEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `transactionId` INTEGER NOT NULL, `smsType` TEXT NOT NULL, `ref` TEXT NOT NULL, `amount` INTEGER NOT NULL, `dateTime` INTEGER NOT NULL, `subjectPrimaryIdentifierType` TEXT NOT NULL, `subjectPrimaryIdentifier` TEXT NOT NULL, `subjectSecondaryIdentifierType` TEXT NOT NULL, `subjectSecondaryIdentifier` TEXT NOT NULL, `cost` INTEGER NOT NULL, `balance` INTEGER NOT NULL, `isIgnored` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transactionId",
+            "columnName": "transactionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "smsType",
+            "columnName": "smsType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "ref",
+            "columnName": "ref",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "dateTime",
+            "columnName": "dateTime",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subjectPrimaryIdentifierType",
+            "columnName": "subjectPrimaryIdentifierType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subjectPrimaryIdentifier",
+            "columnName": "subjectPrimaryIdentifier",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subjectSecondaryIdentifierType",
+            "columnName": "subjectSecondaryIdentifierType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subjectSecondaryIdentifier",
+            "columnName": "subjectSecondaryIdentifier",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cost",
+            "columnName": "cost",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "balance",
+            "columnName": "balance",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isIgnored",
+            "columnName": "isIgnored",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '82b68e13a83a12b21dd49dccb4558068')"
+    ]
+  }
+}

--- a/composeApp/src/androidInstrumentedTest/kotlin/co/ke/foxlysoft/budgetgain/database/AppDatabaseMigrationTest.kt
+++ b/composeApp/src/androidInstrumentedTest/kotlin/co/ke/foxlysoft/budgetgain/database/AppDatabaseMigrationTest.kt
@@ -31,7 +31,7 @@ class AppDatabaseMigrationTest {
     }
 
     @Test
-    fun migrate14To18PreservesBudgetAndSmsData() {
+    fun migrate14To19PreservesBudgetAndSmsData() {
         runBlocking {
             migrationHelper.createDatabase(TEST_DATABASE, 14).apply {
             execSQL(
@@ -54,6 +54,13 @@ class AppDatabaseMigrationTest {
                     'name', 'Test Merchant', '', '', 0, 97500)
                 """.trimIndent()
             )
+            execSQL(
+                """
+                INSERT INTO CategoryEntity (
+                    id, budgetId, name, amount, spentAmount, createdAt
+                ) VALUES (1, 1, 'Food', 50000, 10000, 1706745600)
+                """.trimIndent()
+            )
             close()
         }
 
@@ -70,6 +77,7 @@ class AppDatabaseMigrationTest {
                 assertEquals(100_000L, budget.initialBalance)
                 assertEquals("TESTREF", sms.ref)
                 assertFalse(sms.isIgnored)
+                assertEquals(DEFAULT_CATEGORY_ICON_KEY, database.categoryDao().getCategory(1).iconKey)
             } finally {
                 database.close()
             }

--- a/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/database/AppDatabase.kt
+++ b/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/database/AppDatabase.kt
@@ -9,7 +9,7 @@ import androidx.room.migration.Migration
 //import androidx.room.RoomDatabaseConstructor
 
 @Database(entities = [UserEntity::class, SettingsEntity::class, BudgetEntity::class, CategoryEntity::class,
-    AccountEntity::class, TransactionEntity::class, MpesaSmsEntity::class], version = 18)
+    AccountEntity::class, TransactionEntity::class, SubCategoryEntity::class, MpesaSmsEntity::class], version = 19)
 @ConstructedBy(AppDatabaseConstructor::class)
 abstract class AppDatabase : RoomDatabase() {
     abstract fun settingsDao(): SettingsDao
@@ -18,6 +18,7 @@ abstract class AppDatabase : RoomDatabase() {
     abstract fun categoryDao(): CategoryDao
     abstract fun accountDao(): AccountDao
     abstract fun transactionDao(): TransactionDao
+    abstract fun subCategoryDao(): SubCategoryDao
     abstract fun mpesaSmsDao(): MpesaSmsDao
 }
 

--- a/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/database/CategoryDao.kt
+++ b/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/database/CategoryDao.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.flow.Flow
 @Dao
 interface CategoryDao {
     @Upsert
-    suspend fun upsert(categoryEntity: CategoryEntity)
+    suspend fun upsert(categoryEntity: CategoryEntity): Long
 
     @Delete
     suspend fun delete(categoryEntity: CategoryEntity)
@@ -42,4 +42,7 @@ interface CategoryDao {
 
     @Query("SELECT * FROM CategoryEntity WHERE budgetId = :budgetId AND name = :name")
     suspend fun getBudgetCategoryByName(budgetId: Long, name: String): CategoryEntity
+
+    @Query("SELECT * FROM CategoryEntity WHERE budgetId = :budgetId AND catalogKey = :catalogKey LIMIT 1")
+    suspend fun getBudgetCategoryByCatalogKey(budgetId: Long, catalogKey: String): CategoryEntity?
 }

--- a/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/database/CategoryEntity.kt
+++ b/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/database/CategoryEntity.kt
@@ -12,5 +12,14 @@ data class CategoryEntity(
     var amount: Long,   // amount in cents
     var spentAmount: Long,   // amount in cents
     var trackMode: String? = null,
+    val catalogKey: String? = null,
+    var lightColorArgb: Long = DEFAULT_CATEGORY_LIGHT_COLOR_ARGB,
+    var darkColorArgb: Long = DEFAULT_CATEGORY_DARK_COLOR_ARGB,
+    var iconKey: String = DEFAULT_CATEGORY_ICON_KEY,
     val createdAt: Long = Clock.System.now().epochSeconds,
 )
+
+// Material Blue Grey 700/300 provide safe defaults for existing and custom categories.
+const val DEFAULT_CATEGORY_LIGHT_COLOR_ARGB: Long = 0xFF455A64
+const val DEFAULT_CATEGORY_DARK_COLOR_ARGB: Long = 0xFF90A4AE
+const val DEFAULT_CATEGORY_ICON_KEY: String = "category"

--- a/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/database/CommonCategoryCatalog.kt
+++ b/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/database/CommonCategoryCatalog.kt
@@ -1,0 +1,79 @@
+package co.ke.foxlysoft.budgetgain.database
+
+data class CommonSubCategoryDefinition(
+    val key: String,
+    val name: String,
+    val iconKey: String? = null,
+    val lightColorArgb: Long? = null,
+    val darkColorArgb: Long? = null,
+)
+
+data class CommonCategoryDefinition(
+    val key: String,
+    val name: String,
+    val lightColorArgb: Long,
+    val darkColorArgb: Long,
+    val iconKey: String,
+    val subCategories: List<CommonSubCategoryDefinition> = emptyList(),
+)
+
+object CommonCategoryCatalog {
+    val categories = listOf(
+        category("entertainment", "Entertainment", 0xFFF57C00, 0xFFFFB74D, "celebration",
+            sub("movies", "Movies", "local_movies")),
+        category("family", "Family", 0xFF7B1FA2, 0xFFBA68C8, "family"),
+        category("food", "Food", 0xFF388E3C, 0xFF81C784, "restaurant",
+            sub("bulk", "Bulk", "shopping_cart"),
+            sub("groceries", "Groceries", "eco"),
+            sub("household", "Household", "home"),
+            sub("restaurants", "Restaurants", "hotel"),
+            sub("takeout", "Takeout", "shopping_bag")),
+        category("healthcare", "Healthcare", 0xFF1976D2, 0xFF64B5F6, "local_hospital",
+            sub("medicine", "Medicine", "medication"),
+            sub("consultation", "Consultation", "medical_services")),
+        category("household", "Household", 0xFFF06292, 0xFFF48FB1, "home",
+            sub("cleaning", "Cleaning"),
+            sub("electricity", "Electricity", "lightbulb"),
+            sub("garbage", "Garbage", "delete"),
+            sub("gas", "Gas", "propane_tank"),
+            sub("rent", "Rent", "home"),
+            sub("service", "Service", "build"),
+            sub("water", "Water", "water_drop"),
+            sub("wifi", "Wifi", "wifi")),
+        category("mobile", "Mobile", 0xFF0097A7, 0xFF4DD0E1, "smartphone",
+            sub("airtime", "Airtime"), sub("bundles", "Bundles")),
+        category("shopping", "Shopping", 0xFF5D4037, 0xFFA1887F, "shopping_bag",
+            sub("clothing", "Clothing", "checkroom"),
+            sub("electronics", "Electronics"), sub("general", "General")),
+        category("subscriptions", "Subscriptions", 0xFF303F9F, 0xFF7986CB, "credit_card",
+            sub("music", "Music", "music_note"), sub("streaming", "Streaming", "tv")),
+        category("transport", "Transport", 0xFFFFA000, 0xFFFFD54F, "directions_car",
+            sub("bodaboda", "Bodaboda", "two_wheeler"),
+            sub("tuktuk", "Tuktuk", "rickshaw"),
+            sub("matatu", "Matatu", "directions_bus"),
+            sub("taxi", "Taxi", "local_taxi"),
+            sub("fuel", "Fuel", "local_gas_station")),
+    )
+
+    fun find(key: String): CommonCategoryDefinition? = categories.firstOrNull { it.key == key }
+
+    fun normalizedKey(name: String): String {
+        return name
+            .trim()
+            .lowercase()
+            .replace(Regex("[^a-z0-9]+"), "-")
+            .trim('-')
+    }
+
+    private fun category(
+        key: String,
+        name: String,
+        lightColorArgb: Long,
+        darkColorArgb: Long,
+        iconKey: String,
+        vararg subCategories: CommonSubCategoryDefinition,
+    ) = CommonCategoryDefinition(key, name, lightColorArgb, darkColorArgb, iconKey, subCategories.toList())
+
+    private fun sub(key: String, name: String, iconKey: String? = null) =
+        CommonSubCategoryDefinition(key, name, iconKey)
+}

--- a/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/database/DatabaseMigrations.kt
+++ b/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/database/DatabaseMigrations.kt
@@ -49,7 +49,67 @@ val MIGRATION_16_18 = object : Migration(16, 18) {
     }
 }
 
-val APP_DATABASE_MIGRATIONS = arrayOf(MIGRATION_14_18, MIGRATION_15_18, MIGRATION_16_18)
+val MIGRATION_18_19 = object : Migration(18, 19) {
+    override fun migrate(connection: SQLiteConnection) {
+        connection.exec("ALTER TABLE `CategoryEntity` ADD COLUMN `catalogKey` TEXT DEFAULT NULL")
+        connection.exec("ALTER TABLE `CategoryEntity` ADD COLUMN `lightColorArgb` INTEGER NOT NULL DEFAULT 4282735204")
+        connection.exec("ALTER TABLE `CategoryEntity` ADD COLUMN `darkColorArgb` INTEGER NOT NULL DEFAULT 4287669422")
+        connection.exec("ALTER TABLE `CategoryEntity` ADD COLUMN `iconKey` TEXT NOT NULL DEFAULT 'category'")
+
+        connection.exec(
+            """
+            CREATE TABLE IF NOT EXISTS `SubCategoryEntity` (
+                `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                `categoryId` INTEGER NOT NULL,
+                `catalogKey` TEXT,
+                `name` TEXT NOT NULL,
+                `iconKey` TEXT,
+                `lightColorArgb` INTEGER,
+                `darkColorArgb` INTEGER,
+                `createdAt` INTEGER NOT NULL,
+                FOREIGN KEY(`categoryId`) REFERENCES `CategoryEntity`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE
+            )
+            """.trimIndent()
+        )
+        connection.exec("CREATE INDEX IF NOT EXISTS `index_SubCategoryEntity_categoryId` ON `SubCategoryEntity` (`categoryId`)")
+        connection.exec("CREATE UNIQUE INDEX IF NOT EXISTS `index_SubCategoryEntity_categoryId_catalogKey` ON `SubCategoryEntity` (`categoryId`, `catalogKey`)")
+
+        connection.exec(
+            """
+            CREATE TABLE IF NOT EXISTS `TransactionEntity_new` (
+                `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                `ref` TEXT NOT NULL,
+                `type` TEXT NOT NULL,
+                `description` TEXT NOT NULL,
+                `budgetId` INTEGER NOT NULL,
+                `debitAccountId` INTEGER NOT NULL,
+                `creditAccountId` INTEGER NOT NULL,
+                `categoryId` INTEGER NOT NULL,
+                `subCategoryId` INTEGER,
+                `amount` INTEGER NOT NULL,
+                `createdAt` INTEGER NOT NULL,
+                `timestamp` TEXT NOT NULL,
+                FOREIGN KEY(`subCategoryId`) REFERENCES `SubCategoryEntity`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL
+            )
+            """.trimIndent()
+        )
+        connection.exec(
+            """
+            INSERT INTO `TransactionEntity_new` (
+                `id`, `ref`, `type`, `description`, `budgetId`, `debitAccountId`,
+                `creditAccountId`, `categoryId`, `subCategoryId`, `amount`, `createdAt`, `timestamp`
+            ) SELECT `id`, `ref`, `type`, `description`, `budgetId`, `debitAccountId`,
+                `creditAccountId`, `categoryId`, NULL, `amount`, `createdAt`, `timestamp`
+              FROM `TransactionEntity`
+            """.trimIndent()
+        )
+        connection.exec("DROP TABLE `TransactionEntity`")
+        connection.exec("ALTER TABLE `TransactionEntity_new` RENAME TO `TransactionEntity`")
+        connection.exec("CREATE INDEX IF NOT EXISTS `index_TransactionEntity_subCategoryId` ON `TransactionEntity` (`subCategoryId`)")
+    }
+}
+
+val APP_DATABASE_MIGRATIONS = arrayOf(MIGRATION_14_18, MIGRATION_15_18, MIGRATION_16_18, MIGRATION_18_19)
 
 private fun SQLiteConnection.addIsIgnoredColumn() {
     exec("ALTER TABLE `MpesaSmsEntity` ADD COLUMN `isIgnored` INTEGER NOT NULL DEFAULT 0")

--- a/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/database/SubCategoryDao.kt
+++ b/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/database/SubCategoryDao.kt
@@ -1,0 +1,31 @@
+package co.ke.foxlysoft.budgetgain.database
+
+import androidx.room.Dao
+import androidx.room.Delete
+import androidx.room.Query
+import androidx.room.Upsert
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface SubCategoryDao {
+    @Upsert
+    suspend fun upsert(subCategory: SubCategoryEntity): Long
+
+    @Upsert
+    suspend fun upsertAll(subCategories: List<SubCategoryEntity>)
+
+    @Delete
+    suspend fun delete(subCategory: SubCategoryEntity)
+
+    @Query("SELECT * FROM SubCategoryEntity WHERE categoryId = :categoryId ORDER BY name")
+    fun getForCategoryFlow(categoryId: Long): Flow<List<SubCategoryEntity>>
+
+    @Query("SELECT * FROM SubCategoryEntity WHERE categoryId = :categoryId ORDER BY name")
+    suspend fun getForCategory(categoryId: Long): List<SubCategoryEntity>
+
+    @Query("SELECT * FROM SubCategoryEntity WHERE id = :id")
+    suspend fun get(id: Long): SubCategoryEntity?
+
+    @Query("SELECT EXISTS(SELECT 1 FROM SubCategoryEntity WHERE id = :id AND categoryId = :categoryId)")
+    suspend fun belongsToCategory(id: Long, categoryId: Long): Boolean
+}

--- a/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/database/SubCategoryEntity.kt
+++ b/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/database/SubCategoryEntity.kt
@@ -1,0 +1,38 @@
+package co.ke.foxlysoft.budgetgain.database
+
+import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
+import androidx.room.PrimaryKey
+import kotlin.time.Clock
+
+@Entity(
+    foreignKeys = [
+        ForeignKey(
+            entity = CategoryEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["categoryId"],
+            onDelete = ForeignKey.CASCADE,
+        ),
+    ],
+    indices = [
+        Index("categoryId"),
+        Index(value = ["categoryId", "catalogKey"], unique = true),
+    ],
+)
+data class SubCategoryEntity(
+    @PrimaryKey(autoGenerate = true) val id: Long = 0,
+    val categoryId: Long,
+    val catalogKey: String? = null,
+    var name: String,
+    var iconKey: String? = null,
+    var lightColorArgb: Long? = null,
+    var darkColorArgb: Long? = null,
+    val createdAt: Long = Clock.System.now().epochSeconds,
+)
+
+fun SubCategoryEntity.resolvedIconKey(parent: CategoryEntity): String = iconKey ?: parent.iconKey
+
+fun SubCategoryEntity.resolvedColorArgb(parent: CategoryEntity, isDarkMode: Boolean): Long =
+    if (isDarkMode) darkColorArgb ?: parent.darkColorArgb
+    else lightColorArgb ?: parent.lightColorArgb

--- a/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/database/TransactionDao.kt
+++ b/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/database/TransactionDao.kt
@@ -20,6 +20,9 @@ interface TransactionDao {
     @Query("SELECT * FROM TransactionEntity WHERE categoryId = :categoryId")
     fun getCategoryTransactions(categoryId: Long): Flow<List<TransactionEntity>>
 
+    @Query("SELECT * FROM TransactionEntity WHERE subCategoryId = :subCategoryId")
+    fun getSubCategoryTransactions(subCategoryId: Long): Flow<List<TransactionEntity>>
+
     @Query("SELECT * FROM TransactionEntity WHERE categoryId = :categoryId ORDER BY timestamp DESC LIMIT :limit OFFSET :offset")
     suspend fun getPagingCategoryTransactions(categoryId: Long, limit: Int, offset: Int): List<TransactionEntity>
 

--- a/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/database/TransactionEntity.kt
+++ b/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/database/TransactionEntity.kt
@@ -1,10 +1,22 @@
 package co.ke.foxlysoft.budgetgain.database
 
 import androidx.room.Entity
+import androidx.room.ForeignKey
+import androidx.room.Index
 import androidx.room.PrimaryKey
 import kotlin.time.Clock
 
-@Entity
+@Entity(
+    foreignKeys = [
+        ForeignKey(
+            entity = SubCategoryEntity::class,
+            parentColumns = ["id"],
+            childColumns = ["subCategoryId"],
+            onDelete = ForeignKey.SET_NULL,
+        ),
+    ],
+    indices = [Index("subCategoryId")],
+)
 data class TransactionEntity(
     @PrimaryKey(autoGenerate = true) val id: Long = 0,
     val ref: String = "",   // external reference
@@ -14,6 +26,7 @@ data class TransactionEntity(
     val debitAccountId: Long = 0,
     val creditAccountId: Long = 0,
     val categoryId: Long = 0,
+    val subCategoryId: Long? = null,
     val amount: Long = 0, // in cents
     val createdAt: Long = Clock.System.now().epochSeconds,
     val timestamp: String = "", // yyyy-MM-dd HH:mm

--- a/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/repos/CategoryRepository.kt
+++ b/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/repos/CategoryRepository.kt
@@ -3,12 +3,17 @@ package co.ke.foxlysoft.budgetgain.repos
 import co.ke.foxlysoft.budgetgain.database.AppDatabase
 import co.ke.foxlysoft.budgetgain.database.BudgetEntity
 import co.ke.foxlysoft.budgetgain.database.CategoryEntity
+import co.ke.foxlysoft.budgetgain.database.CommonCategoryDefinition
+import co.ke.foxlysoft.budgetgain.database.SubCategoryEntity
+import androidx.room.immediateTransaction
+import androidx.room.useWriterConnection
 import kotlinx.coroutines.flow.Flow
 
 class CategoryRepository(
-    db: AppDatabase
+    private val db: AppDatabase
 ) {
     private val categoryDao = db.categoryDao()
+    private val subCategoryDao = db.subCategoryDao()
 
     suspend fun upsertCategory(categoryEntity: CategoryEntity) = categoryDao.upsert(categoryEntity)
 
@@ -39,5 +44,52 @@ class CategoryRepository(
 
     suspend fun getBudgetCategoryByName(budgetId: Long, categoryName: String): CategoryEntity {
         return categoryDao.getBudgetCategoryByName(budgetId, categoryName)
+    }
+
+    suspend fun getBudgetCategoryByCatalogKey(budgetId: Long, catalogKey: String) =
+        categoryDao.getBudgetCategoryByCatalogKey(budgetId, catalogKey)
+
+    fun getSubCategoriesFlow(categoryId: Long) = subCategoryDao.getForCategoryFlow(categoryId)
+
+    suspend fun getSubCategories(categoryId: Long) = subCategoryDao.getForCategory(categoryId)
+
+    suspend fun getSubCategory(id: Long) = subCategoryDao.get(id)
+
+    suspend fun upsertSubCategory(subCategory: SubCategoryEntity) = subCategoryDao.upsert(subCategory)
+
+    suspend fun deleteSubCategory(subCategory: SubCategoryEntity) = subCategoryDao.delete(subCategory)
+
+    suspend fun installCommonCategory(
+        budgetId: Long,
+        definition: CommonCategoryDefinition,
+        amount: Long = 0,
+    ): Long = db.useWriterConnection { transactor ->
+        transactor.immediateTransaction {
+            categoryDao.getBudgetCategoryByCatalogKey(budgetId, definition.key)?.id ?: run {
+                val categoryId = categoryDao.upsert(
+                    CategoryEntity(
+                        budgetId = budgetId,
+                        catalogKey = definition.key,
+                        name = definition.name,
+                        amount = amount,
+                        spentAmount = 0,
+                        lightColorArgb = definition.lightColorArgb,
+                        darkColorArgb = definition.darkColorArgb,
+                        iconKey = definition.iconKey,
+                    )
+                )
+                subCategoryDao.upsertAll(definition.subCategories.map { child ->
+                    SubCategoryEntity(
+                        categoryId = categoryId,
+                        catalogKey = "${definition.key}.${child.key}",
+                        name = child.name,
+                        iconKey = child.iconKey,
+                        lightColorArgb = child.lightColorArgb,
+                        darkColorArgb = child.darkColorArgb,
+                    )
+                })
+                categoryId
+            }
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/repos/TransactionRepository.kt
+++ b/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/repos/TransactionRepository.kt
@@ -11,12 +11,21 @@ import kotlinx.datetime.toLocalDateTime
 class TransactionRepository(db: AppDatabase) {
     private val transactionDao = db.transactionDao()
     private val accountDao = db.accountDao()
+    private val subCategoryDao = db.subCategoryDao()
 
-    suspend fun upsertTransaction(transactionEntity: TransactionEntity) : Long = transactionDao.upsert(transactionEntity)
+    suspend fun upsertTransaction(transactionEntity: TransactionEntity): Long {
+        val subCategoryId = transactionEntity.subCategoryId
+        require(subCategoryId == null || subCategoryDao.belongsToCategory(subCategoryId, transactionEntity.categoryId)) {
+            "Subcategory $subCategoryId does not belong to category ${transactionEntity.categoryId}"
+        }
+        return transactionDao.upsert(transactionEntity)
+    }
 
     suspend fun deleteTransaction(transactionEntity: TransactionEntity) = transactionDao.delete(transactionEntity)
 
     fun getCategoryTransactions(categoryId: Long) = transactionDao.getCategoryTransactions(categoryId)
+
+    fun getSubCategoryTransactions(subCategoryId: Long) = transactionDao.getSubCategoryTransactions(subCategoryId)
 
     suspend fun getPagingCategoryTransactions(categoryId: Long, limit: Int, offset: Int) = transactionDao.getPagingCategoryTransactions(categoryId, limit, offset)
 

--- a/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/ui/AddCategoryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/ui/AddCategoryScreen.kt
@@ -1,6 +1,8 @@
 package co.ke.foxlysoft.budgetgain.ui
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -8,12 +10,19 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -26,6 +35,11 @@ import androidx.compose.ui.unit.dp
 import budgetgain.composeapp.generated.resources.Res
 import budgetgain.composeapp.generated.resources.calculator_variant_outline
 import co.ke.foxlysoft.budgetgain.database.CategoryEntity
+import co.ke.foxlysoft.budgetgain.database.CommonCategoryDefinition
+import co.ke.foxlysoft.budgetgain.database.CommonCategoryCatalog
+import co.ke.foxlysoft.budgetgain.database.DEFAULT_CATEGORY_DARK_COLOR_ARGB
+import co.ke.foxlysoft.budgetgain.database.DEFAULT_CATEGORY_ICON_KEY
+import co.ke.foxlysoft.budgetgain.database.DEFAULT_CATEGORY_LIGHT_COLOR_ARGB
 import co.ke.foxlysoft.budgetgain.ui.components.BGainOutlineField
 import co.ke.foxlysoft.budgetgain.calc.CalculatorDialog
 import co.ke.foxlysoft.budgetgain.utils.ErrorStatus
@@ -48,11 +62,17 @@ fun AddCategoryScreen(
 
     val currentBudget = addCategoryScreenViewModel.currentBudget.collectAsState().value
     var categoryName by remember { mutableStateOf("") }
+    var selectedCommonCategory by remember { mutableStateOf<CommonCategoryDefinition?>(null) }
     var categoryNameErrorStatus by remember { mutableStateOf(ErrorStatus(isError = false)) }
     var categoryAmount by remember { mutableStateOf("") }
+    var customSubCategories by remember { mutableStateOf("") }
     var categoryAmountErrorStatus by remember { mutableStateOf(ErrorStatus(isError = false))}
+    var showCustomSubCategoryDialog by remember { mutableStateOf(false) }
+    var customSubCategoryName by remember { mutableStateOf("") }
 
     var isCalculatorOpen by remember { mutableStateOf(false) }
+    val installedCatalogKeys by addCategoryScreenViewModel.getBudgetCategoriesFlow(id)
+        .collectAsState(initial = emptyList())
 
     fun clearErrorStatus() {
         categoryNameErrorStatus = ErrorStatus(isError = false)
@@ -96,16 +116,46 @@ fun AddCategoryScreen(
 
     Column(
         modifier = Modifier.fillMaxSize()
+            .verticalScroll(rememberScrollState())
             .padding(16.dp)
     ){
         Text(text="Add Category $id")
+        Text("Choose a common category as a template or enter a custom category below")
+        LazyVerticalGrid(
+            columns = GridCells.Fixed(2),
+            modifier = Modifier.fillMaxWidth().height(280.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            items(addCategoryScreenViewModel.commonCategories, key = { it.key }) { definition ->
+                val alreadyAdded = definition.key in installedCatalogKeys.mapNotNull { it.catalogKey }
+                FilterChip(
+                    selected = selectedCommonCategory?.key == definition.key,
+                    enabled = !alreadyAdded,
+                    onClick = {
+                        selectedCommonCategory = definition
+                        categoryName = definition.name
+                        categoryNameErrorStatus = ErrorStatus(isError = false)
+                    },
+                    label = { Text(if (alreadyAdded) "${definition.name} ✓" else definition.name) },
+                    leadingIcon = {
+                        Icon(
+                            imageVector = MaterialCategoryIconRegistry.resolve(definition.iconKey),
+                            contentDescription = null,
+                        )
+                    },
+                )
+            }
+        }
         BGainOutlineField(
             modifier = Modifier
                 .fillMaxWidth(),
             labelStr = "Category Name",
             Value = categoryName,
             errorStatus = categoryNameErrorStatus,
-            onValueChange = { categoryName = it },
+            onValueChange = {
+                categoryName = it
+            },
             validator = {
                 if (it.isEmpty()){
                     categoryNameErrorStatus = ErrorStatus(isError = true, errorMsg = "Budget Name is required")
@@ -114,6 +164,19 @@ fun AddCategoryScreen(
                 categoryNameErrorStatus = ErrorStatus(isError = false)
             },
             submitAttempted = submitAttempted
+        )
+        FilterChip(
+            selected = false,
+            onClick = { showCustomSubCategoryDialog = true },
+            label = { Text("Add subcategory") },
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        Text(
+            text = if (customSubCategories.isBlank()) {
+                "No extra subcategories added"
+            } else {
+                "Extra subcategories: $customSubCategories"
+            }
         )
         Text("Max: ${centsToString(currentBudget.initialBalance - currentBudget.budgetedAmount)}")
         BGainOutlineField(
@@ -145,8 +208,44 @@ fun AddCategoryScreen(
                         contentDescription = "Open Calculator"
                     )
                 }
+        }
+    )
+
+    if (showCustomSubCategoryDialog) {
+        AlertDialog(
+            onDismissRequest = { showCustomSubCategoryDialog = false },
+            title = { Text("Add subcategory") },
+            text = {
+                OutlinedTextField(
+                    value = customSubCategoryName,
+                    onValueChange = { customSubCategoryName = it },
+                    modifier = Modifier.fillMaxWidth(),
+                    label = { Text("Subcategory name") },
+                    singleLine = true,
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    enabled = customSubCategoryName.isNotBlank(),
+                    onClick = {
+                        val trimmed = customSubCategoryName.trim()
+                        customSubCategories = listOf(customSubCategories, trimmed)
+                            .filter { it.isNotBlank() }
+                            .joinToString(", ")
+                        customSubCategoryName = ""
+                        showCustomSubCategoryDialog = false
+                    }
+                ) {
+                    Text("Add")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showCustomSubCategoryDialog = false }) {
+                    Text("Cancel")
+                }
             }
         )
+    }
         Spacer(modifier = Modifier.height(8.dp))
         Row(
             modifier = Modifier.fillMaxWidth(),
@@ -166,9 +265,17 @@ fun AddCategoryScreen(
                         name = categoryName,
                         amount = amountToCents(categoryAmount),
                         spentAmount = 0,
-                    )
+                        catalogKey = if (selectedCommonCategory != null) {
+                            CommonCategoryCatalog.normalizedKey(categoryName)
+                        } else null,
+                        lightColorArgb = DEFAULT_CATEGORY_LIGHT_COLOR_ARGB,
+                        darkColorArgb = DEFAULT_CATEGORY_DARK_COLOR_ARGB,
+                        iconKey = DEFAULT_CATEGORY_ICON_KEY,
+                    ),
+                    commonDefinition = selectedCommonCategory,
+                    customSubCategoryNames = customSubCategories.split(','),
+                    onComplete = onNavigateBack,
                 )
-                onNavigateBack()
             }){
                 Text(text = "Add Category")
             }

--- a/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/ui/AddCategoryScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/ui/AddCategoryScreenViewModel.kt
@@ -4,6 +4,12 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.ke.foxlysoft.budgetgain.database.BudgetEntity
 import co.ke.foxlysoft.budgetgain.database.CategoryEntity
+import co.ke.foxlysoft.budgetgain.database.CommonCategoryCatalog
+import co.ke.foxlysoft.budgetgain.database.CommonCategoryDefinition
+import co.ke.foxlysoft.budgetgain.database.DEFAULT_CATEGORY_DARK_COLOR_ARGB
+import co.ke.foxlysoft.budgetgain.database.DEFAULT_CATEGORY_ICON_KEY
+import co.ke.foxlysoft.budgetgain.database.DEFAULT_CATEGORY_LIGHT_COLOR_ARGB
+import co.ke.foxlysoft.budgetgain.database.SubCategoryEntity
 import co.ke.foxlysoft.budgetgain.repos.BudgetRepository
 import co.ke.foxlysoft.budgetgain.repos.CategoryRepository
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -15,6 +21,7 @@ class AddCategoryScreenViewModel (
     private val categoryRepository: CategoryRepository,
     private val budgetRepository: BudgetRepository
 ): ViewModel(){
+    val commonCategories = CommonCategoryCatalog.categories
     private val _currentBudget =
         MutableStateFlow(BudgetEntity())
     val currentBudget: StateFlow<BudgetEntity>
@@ -34,11 +41,64 @@ class AddCategoryScreenViewModel (
             }
         )
     }
-    fun createCategory(categoryEntity: CategoryEntity){
+    fun getBudgetCategoriesFlow(budgetId: Long) = categoryRepository.getBudgetCategoriesFlow(budgetId)
+
+    fun createCategory(
+        categoryEntity: CategoryEntity,
+        commonDefinition: CommonCategoryDefinition? = null,
+        customSubCategoryNames: List<String> = emptyList(),
+        onComplete: () -> Unit = {},
+    ) {
         viewModelScope.launch {
-            categoryRepository.upsertCategory(categoryEntity)
+            val categoryId = if (commonDefinition == null) {
+                categoryRepository.upsertCategory(categoryEntity)
+            } else {
+                categoryRepository.upsertCategory(
+                    categoryEntity.copy(
+                        catalogKey = CommonCategoryCatalog.normalizedKey(categoryEntity.name),
+                        lightColorArgb = commonDefinition.lightColorArgb,
+                        darkColorArgb = commonDefinition.darkColorArgb,
+                        iconKey = commonDefinition.iconKey,
+                    )
+                )
+            }
+            val existingNames = categoryRepository.getSubCategories(categoryId)
+                .map { it.name.lowercase() }.toMutableSet()
+            if (commonDefinition != null) {
+                commonDefinition.subCategories
+                    .map { child ->
+                        SubCategoryEntity(
+                            categoryId = categoryId,
+                            catalogKey = "${CommonCategoryCatalog.normalizedKey(categoryEntity.name)}.${child.key}",
+                            name = child.name,
+                            iconKey = child.iconKey,
+                            lightColorArgb = child.lightColorArgb ?: commonDefinition.lightColorArgb,
+                            darkColorArgb = child.darkColorArgb ?: commonDefinition.darkColorArgb,
+                        )
+                    }
+                    .forEach { subCategory ->
+                        if (subCategory.name.lowercase() !in existingNames) {
+                            categoryRepository.upsertSubCategory(subCategory)
+                            existingNames += subCategory.name.lowercase()
+                        }
+                    }
+            }
+            customSubCategoryNames
+                .map { it.trim() }
+                .filter { it.isNotEmpty() && it.lowercase() !in existingNames }
+                .distinctBy { it.lowercase() }
+                .forEach { name ->
+                    categoryRepository.upsertSubCategory(
+                        SubCategoryEntity(
+                            categoryId = categoryId,
+                            catalogKey = CommonCategoryCatalog.normalizedKey(name),
+                            name = name
+                        )
+                    )
+                }
             // update budgeted amount of budget
             budgetRepository.incrementBudgetedAmount(categoryEntity.budgetId, categoryEntity.amount)
+            onComplete()
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/ui/CategoryDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/ui/CategoryDetailsScreen.kt
@@ -2,6 +2,8 @@ package co.ke.foxlysoft.budgetgain.ui
 
 import androidx.compose.animation.core.EaseInOutCubic
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -17,8 +19,6 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.BarChart
-import androidx.compose.material.icons.filled.Category
-import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.Receipt
 import androidx.compose.material.icons.outlined.CalendarMonth
 import androidx.compose.material.icons.outlined.CalendarViewMonth
@@ -26,17 +26,14 @@ import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.Shop
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuAnchorType
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.PrimaryScrollableTabRow
 import androidx.compose.material3.PrimaryTabRow
@@ -53,20 +50,21 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import co.ke.foxlysoft.budgetgain.database.AccountEntity
 import co.ke.foxlysoft.budgetgain.database.CategoryEntity
+import co.ke.foxlysoft.budgetgain.database.SubCategoryEntity
 import co.ke.foxlysoft.budgetgain.database.TransactionEntity
 import co.ke.foxlysoft.budgetgain.repos.MerchantSummary
 import co.ke.foxlysoft.budgetgain.ui.Theme.BudgetGainTheme
-import co.ke.foxlysoft.budgetgain.ui.Theme.Purple600
+import co.ke.foxlysoft.budgetgain.ui.displayColor
+import co.ke.foxlysoft.budgetgain.ui.displayIcon
 import co.ke.foxlysoft.budgetgain.ui.charts.MonthLineChart
 import co.ke.foxlysoft.budgetgain.ui.components.BGPaginatedList
 import co.ke.foxlysoft.budgetgain.ui.components.BGainPaginationController
@@ -104,6 +102,7 @@ fun CategoryDetailsScreen(
         merchantsSummary = merchantSummary,
         dailyData = dailyData,
         onGetMerchantAccount = categoryDetailsScreenViewModel::getMerchantAccount,
+        onGetSubCategory = categoryDetailsScreenViewModel::getSubCategory,
         onDeleteTransaction = categoryDetailsScreenViewModel::deleteTransaction,
         onGetCategoryTransactions = categoryDetailsScreenViewModel::getCategoryTransactions,
         onOpenConfirmSnackbar
@@ -117,6 +116,7 @@ fun CategoryDetailsContent(
     merchantsSummary: List<MerchantSummary> = emptyList(),
     dailyData: List<Pair<Int, Long>> = emptyList(),
     onGetMerchantAccount: suspend (TransactionEntity) -> AccountEntity,
+    onGetSubCategory: suspend (Long) -> SubCategoryEntity?,
     onDeleteTransaction: suspend (TransactionEntity) -> Unit,
     onGetCategoryTransactions: suspend (Int, Int) -> List<TransactionEntity>,
     onOpenConfirmSnackbar: (msg: String, actionLabel: String, onConfirm: () -> Unit) -> Unit
@@ -136,7 +136,22 @@ fun CategoryDetailsContent(
         modifier = Modifier.fillMaxSize()
             .padding(16.dp)
     ){
-        Text(text= category.name, style = MaterialTheme.typography.headlineLarge)
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Box(
+                modifier = Modifier
+                    .padding(end = 10.dp)
+                    .background(category.displayColor(isSystemInDarkTheme()), shape = CircleShape),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = category.displayIcon(),
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onPrimary,
+                    modifier = Modifier.padding(2.dp)
+                )
+            }
+            Text(text = category.name, style = MaterialTheme.typography.headlineLarge)
+        }
         Text(text = "Remaining: Ksh${centsToString(category.amount - category.spentAmount)}")
         Spacer(modifier = Modifier.height(8.dp))
 
@@ -169,33 +184,43 @@ fun CategoryDetailsContent(
         ) {
             if (selectedTabIndex.value == 0) {
                 val paginationController = remember { BGainPaginationController() }
-                BGPaginatedList(
-                    onGetKey = { it.id },
-                    onGetItem = {
-                        TransactionItem(
-                            onGetMerchantAccount = onGetMerchantAccount,
-                            it,
-                            onDelete = {
-                                // TODO: add a confirmation dialog
-                                onOpenConfirmSnackbar(
-                                    "Are you sure you want to delete?",
-                                    "Confirm",
-                                    {
-                                        // Perform the delete action
-                                        coroutineScope.launch {
-                                            onDeleteTransaction(it)
-                                            paginationController.refreshAllPages()
+                Column {
+                    Text(
+                        text = "Tap transaction to open menu",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    BGPaginatedList(
+                        onGetKey = { it.id },
+                        onGetItem = {
+                            TransactionItem(
+                                onGetMerchantAccount = onGetMerchantAccount,
+                                onGetSubCategory = onGetSubCategory,
+                                category = category,
+                                transaction = it,
+                                onDelete = {
+                                    // TODO: add a confirmation dialog
+                                    onOpenConfirmSnackbar(
+                                        "Are you sure you want to delete?",
+                                        "Confirm",
+                                        {
+                                            // Perform the delete action
+                                            coroutineScope.launch {
+                                                onDeleteTransaction(it)
+                                                paginationController.refreshAllPages()
+                                            }
                                         }
-                                    }
-                                )
+                                    )
 
-                            })
-                    },
-                    onGetItems = { limit, offset ->
-                        onGetCategoryTransactions(limit, offset)
-                    },
-                    controller = paginationController
-                )
+                                })
+                        },
+                        onGetItems = { limit, offset ->
+                            onGetCategoryTransactions(limit, offset)
+                        },
+                        controller = paginationController
+                    )
+                }
             }
             if (selectedTabIndex.value == 1) {
                 LazyColumn(
@@ -259,24 +284,47 @@ fun CategoryDetailsContent(
 @Composable
 fun TransactionItem(
     onGetMerchantAccount: suspend (TransactionEntity) -> AccountEntity,
+    onGetSubCategory: suspend (Long) -> SubCategoryEntity?,
+    category: CategoryEntity,
     transaction: TransactionEntity,
     onDelete: () -> Unit
 ) {
-    // State to track the expanded state of the menu
     var menuExpanded by remember { mutableStateOf(false) }
 
     var merchantAccount by remember { mutableStateOf(AccountEntity(merchantName = "Sample Merchant")) }
+    var subCategory by remember { mutableStateOf<SubCategoryEntity?>(null) }
 
     LaunchedEffect(key1 = Unit) {
         merchantAccount = onGetMerchantAccount(transaction)
+        subCategory = transaction.subCategoryId?.let { onGetSubCategory(it) }
     }
 
-    Card{
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        onClick = { menuExpanded = true }
+    ){
         Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(8.dp)
         ) {
+            Box(
+                modifier = Modifier
+                    .padding(end = 8.dp)
+                    .background(
+                        (subCategory?.displayColor(category, isSystemInDarkTheme())
+                            ?: category.displayColor(isSystemInDarkTheme())),
+                        shape = CircleShape
+                    ),
+                contentAlignment = Alignment.Center
+            ) {
+                Icon(
+                    imageVector = subCategory?.displayIcon(category) ?: category.displayIcon(),
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onPrimary,
+                    modifier = Modifier.padding(2.dp)
+                )
+            }
             var description = transaction.description
             if (transaction.description.length > 10) {
                 description = description.take(10) +"..."
@@ -291,27 +339,18 @@ fun TransactionItem(
                 Text(text = transaction.timestamp, style = TextStyle(fontSize = 12.sp))
                 Text(text = "Ksh${centsToString(transaction.amount)}", style = MaterialTheme.typography.bodyLarge)
             }
-            Box(modifier = Modifier.weight(1f)) {
-                IconButton(onClick = {
-                    menuExpanded = true
-                }) {
-                    Icon(
-                        imageVector = Icons.Default.MoreVert,
-                        contentDescription = "Menu"
-                    )
-                }
-                // Dropdown menu
+            Box {
                 DropdownMenu(
                     expanded = menuExpanded,
                     onDismissRequest = { menuExpanded = false }
                 ) {
-                    DropdownMenuItem(onClick = {
-                        onDelete()
-                        menuExpanded = false
-                    },
-                        text = {
-                            Text("Delete")
-                        })
+                    DropdownMenuItem(
+                        onClick = {
+                            onDelete()
+                            menuExpanded = false
+                        },
+                        text = { Text("Delete") }
+                    )
                 }
             }
         }
@@ -406,6 +445,7 @@ fun CategoryDetailsContentPreview() {
                 category = sampleCategory,
                 merchantsSummary = sampleMerchantSummaries,
                 onGetMerchantAccount = { AccountEntity(merchantName = "Sample Merchant") },
+                onGetSubCategory = { null },
                 onDeleteTransaction = {},
                 onGetCategoryTransactions = { _, _ -> sampleTransactions },
                 onOpenConfirmSnackbar = { _, _, _ -> }
@@ -417,6 +457,13 @@ fun CategoryDetailsContentPreview() {
 @Preview(showBackground = true)
 @Composable
 fun TransactionItemPreview() {
+    val sampleCategory = CategoryEntity(
+        id = 1,
+        budgetId = 1,
+        name = "Groceries",
+        amount = 150_000,
+        spentAmount = 62_500
+    )
     val sampleTransaction = TransactionEntity(
         id = 1,
         ref = "TXN-003",
@@ -430,6 +477,8 @@ fun TransactionItemPreview() {
         Surface {
             TransactionItem(
                 onGetMerchantAccount = { AccountEntity(merchantName = "Sample Merchant") },
+                onGetSubCategory = { null },
+                category = sampleCategory,
                 transaction = sampleTransaction,
                 onDelete = {}
             )
@@ -440,6 +489,13 @@ fun TransactionItemPreview() {
 @Preview(showBackground = true)
 @Composable
 fun DarkTransactionItemPreview() {
+    val sampleCategory = CategoryEntity(
+        id = 1,
+        budgetId = 1,
+        name = "Groceries",
+        amount = 150_000,
+        spentAmount = 62_500
+    )
     val sampleTransaction = TransactionEntity(
         id = 1,
         ref = "TXN-003",
@@ -453,6 +509,8 @@ fun DarkTransactionItemPreview() {
         Surface {
             TransactionItem(
                 onGetMerchantAccount = { AccountEntity(merchantName = "Sample Merchant") },
+                onGetSubCategory = { null },
+                category = sampleCategory,
                 transaction = sampleTransaction,
                 onDelete = {}
             )

--- a/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/ui/CategoryDetailsScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/ui/CategoryDetailsScreenViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.room.Transaction
 import co.ke.foxlysoft.budgetgain.database.AccountEntity
 import co.ke.foxlysoft.budgetgain.database.CategoryEntity
+import co.ke.foxlysoft.budgetgain.database.SubCategoryEntity
 import co.ke.foxlysoft.budgetgain.database.TransactionEntity
 import co.ke.foxlysoft.budgetgain.repos.AccountRepository
 import co.ke.foxlysoft.budgetgain.repos.BudgetRepository
@@ -57,6 +58,10 @@ class CategoryDetailsScreenViewModel(
 
     suspend fun getMerchantAccount(transaction: TransactionEntity): AccountEntity {
         return accountRepository.getAccount(transaction.creditAccountId)
+    }
+
+    suspend fun getSubCategory(subCategoryId: Long): SubCategoryEntity? {
+        return categoryRepository.getSubCategory(subCategoryId)
     }
 
     @Transaction

--- a/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/ui/CategoryPresentation.kt
+++ b/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/ui/CategoryPresentation.kt
@@ -1,0 +1,56 @@
+package co.ke.foxlysoft.budgetgain.ui
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.*
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import co.ke.foxlysoft.budgetgain.database.CategoryEntity
+import co.ke.foxlysoft.budgetgain.database.SubCategoryEntity
+import co.ke.foxlysoft.budgetgain.database.resolvedColorArgb
+import co.ke.foxlysoft.budgetgain.database.resolvedIconKey
+
+fun CategoryEntity.displayColor(isDarkMode: Boolean): Color =
+    Color(if (isDarkMode) darkColorArgb else lightColorArgb)
+
+fun SubCategoryEntity.displayColor(parent: CategoryEntity, isDarkMode: Boolean): Color =
+    Color(resolvedColorArgb(parent, isDarkMode))
+
+fun CategoryEntity.displayIcon(): ImageVector = MaterialCategoryIconRegistry.resolve(iconKey)
+
+fun SubCategoryEntity.displayIcon(parent: CategoryEntity): ImageVector =
+    MaterialCategoryIconRegistry.resolve(resolvedIconKey(parent))
+
+object MaterialCategoryIconRegistry {
+    fun resolve(key: String): ImageVector = when (key) {
+        "celebration" -> Icons.Default.Celebration
+        "local_movies" -> Icons.Default.LocalMovies
+        "family" -> Icons.Default.FamilyRestroom
+        "restaurant" -> Icons.Default.Restaurant
+        "shopping_cart" -> Icons.Default.ShoppingCart
+        "eco" -> Icons.Default.Eco
+        "home" -> Icons.Default.Home
+        "hotel" -> Icons.Default.Hotel
+        "shopping_bag" -> Icons.Default.ShoppingBag
+        "local_hospital" -> Icons.Default.LocalHospital
+        "medication" -> Icons.Default.Medication
+        "medical_services" -> Icons.Default.MedicalServices
+        "lightbulb" -> Icons.Default.Lightbulb
+        "delete" -> Icons.Default.Delete
+        "build" -> Icons.Default.Build
+        "water_drop" -> Icons.Default.WaterDrop
+        "wifi" -> Icons.Default.Wifi
+        "smartphone" -> Icons.Default.Smartphone
+        "checkroom" -> Icons.Default.Checkroom
+        "credit_card" -> Icons.Default.CreditCard
+        "music_note" -> Icons.Default.MusicNote
+        "tv" -> Icons.Default.Tv
+        "directions_car" -> Icons.Default.DirectionsCar
+        "two_wheeler" -> Icons.Default.TwoWheeler
+        "directions_bus" -> Icons.Default.DirectionsBus
+        "local_taxi" -> Icons.Default.LocalTaxi
+        "local_gas_station" -> Icons.Default.LocalGasStation
+        "rickshaw" -> Icons.Default.Rickshaw
+        "propane_tank" -> Icons.Default.PropaneTank
+        else -> Icons.Default.Category
+    }
+}

--- a/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/ui/CategoryPresentation.kt
+++ b/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/ui/CategoryPresentation.kt
@@ -49,8 +49,8 @@ object MaterialCategoryIconRegistry {
         "directions_bus" -> Icons.Default.DirectionsBus
         "local_taxi" -> Icons.Default.LocalTaxi
         "local_gas_station" -> Icons.Default.LocalGasStation
-        "rickshaw" -> Icons.Default.Rickshaw
-        "propane_tank" -> Icons.Default.PropaneTank
+        "rickshaw" -> Icons.Default.TwoWheeler
+        "propane_tank" -> Icons.Default.LocalGasStation
         else -> Icons.Default.Category
     }
 }

--- a/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/ui/CreateBudgetScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/ui/CreateBudgetScreenViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import androidx.room.Transaction
 import co.ke.foxlysoft.budgetgain.database.BudgetEntity
 import co.ke.foxlysoft.budgetgain.database.CategoryEntity
+import co.ke.foxlysoft.budgetgain.database.SubCategoryEntity
 import co.ke.foxlysoft.budgetgain.repos.BudgetRepository
 import co.ke.foxlysoft.budgetgain.repos.CategoryRepository
 import kotlinx.coroutines.Job
@@ -59,11 +60,28 @@ class CreateBudgetScreenViewModel(
                 categories.forEach {
                     val categoryEntity = CategoryEntity(
                         budgetId = budgetEntity.id,
+                        catalogKey = it.catalogKey,
                         name = it.name,
                         amount = it.amount,
                         spentAmount = 0L,
+                        trackMode = it.trackMode,
+                        lightColorArgb = it.lightColorArgb,
+                        darkColorArgb = it.darkColorArgb,
+                        iconKey = it.iconKey,
                     )
-                    categoryRepository.upsertCategory(categoryEntity)
+                    val newCategoryId = categoryRepository.upsertCategory(categoryEntity)
+                    categoryRepository.getSubCategories(it.id).forEach { child ->
+                        categoryRepository.upsertSubCategory(
+                            SubCategoryEntity(
+                                categoryId = newCategoryId,
+                                catalogKey = child.catalogKey,
+                                name = child.name,
+                                iconKey = child.iconKey,
+                                lightColorArgb = child.lightColorArgb,
+                                darkColorArgb = child.darkColorArgb,
+                            )
+                        )
+                    }
                 }
 
                 budgetRepository.upsertBudget(budgetEntity)

--- a/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/ui/DailyUsageScreen.kt
+++ b/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/ui/DailyUsageScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CalendarMonth
 import androidx.compose.material.icons.filled.CalendarToday
+import androidx.compose.material.icons.filled.Category
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.CheckCircle
@@ -29,6 +30,8 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -37,10 +40,12 @@ import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.VerticalDivider
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -59,17 +64,20 @@ import co.ke.foxlysoft.budgetgain.my_calendar.DayStatus
 import co.ke.foxlysoft.budgetgain.my_calendar.MonthCalendar
 import co.ke.foxlysoft.budgetgain.ui.Theme.BudgetGainTheme
 import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.isoDayNumber
 import kotlinx.datetime.todayIn
 import kotlin.math.roundToInt
 import kotlin.time.Clock
+import kotlinx.datetime.toInstant
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import co.ke.foxlysoft.budgetgain.database.BudgetEntity
 import co.ke.foxlysoft.budgetgain.database.TransactionEntity
 import co.ke.foxlysoft.budgetgain.database.MpesaSmsEntity
 import co.ke.foxlysoft.budgetgain.database.CategoryEntity
+import co.ke.foxlysoft.budgetgain.database.SubCategoryEntity
 import co.ke.foxlysoft.budgetgain.utils.centsToString
 import co.ke.foxlysoft.budgetgain.utils.amountToCents
 import co.ke.foxlysoft.budgetgain.utils.isValidAmount
@@ -94,10 +102,9 @@ fun DailyUsageScreen(
     val uncategorizedTransactions by dailyUsageScreenViewModel.uncategorizedTransactions.collectAsStateWithLifecycle()
     val isUncategorizedLoading by dailyUsageScreenViewModel.isUncategorizedLoading.collectAsStateWithLifecycle()
     val selectableCategories by categorizationViewModel.selectableCategories.collectAsStateWithLifecycle()
+    val selectableSubCategories by categorizationViewModel.selectableSubCategories.collectAsStateWithLifecycle()
 
-    if (isCalendarLoading) {
-        DailyUsageLoadingScreen()
-    } else {
+    Box(modifier = Modifier.fillMaxSize()) {
         DailyUsageScreenContent(
             budget = budget,
             statusByDate = dayStatusMap,
@@ -113,17 +120,31 @@ fun DailyUsageScreen(
             onLoadUncategorized = dailyUsageScreenViewModel::loadUncategorizedTransactions,
             onIgnoreUncategorized = dailyUsageScreenViewModel::ignoreUncategorizedTransaction,
             selectableCategories = selectableCategories,
+            selectableSubCategories = selectableSubCategories,
             onCategorySearch = categorizationViewModel::updateCategorySearchQuery,
+            onCategorySelected = categorizationViewModel::loadSubCategories,
+            onCreateCustomSubCategory = categorizationViewModel::createCustomSubCategory,
+            onGetCategory = dailyUsageScreenViewModel::getCategory,
+            onGetSubCategory = dailyUsageScreenViewModel::getSubCategory,
             onCategorizeSingle = categorizationViewModel::categorizeSms,
             onCategorizeBulk = categorizationViewModel::categorizeBulkSms,
             onCategorizationComplete = dailyUsageScreenViewModel::refreshSelectedDay
         )
+
+        if (isCalendarLoading) {
+            DailyUsageLoadingOverlay()
+        }
     }
 }
 
 @Composable
-private fun DailyUsageLoadingScreen() {
-    Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+private fun DailyUsageLoadingOverlay() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.72f)),
+        contentAlignment = Alignment.Center
+    ) {
         Column(horizontalAlignment = Alignment.CenterHorizontally) {
             CircularProgressIndicator()
             Spacer(modifier = Modifier.height(16.dp))
@@ -164,9 +185,14 @@ fun DailyUsageScreenContent(
     onLoadUncategorized: () -> Unit = {},
     onIgnoreUncategorized: (MpesaSmsEntity) -> Unit = {},
     selectableCategories: List<CategoryEntity> = emptyList(),
+    selectableSubCategories: List<SubCategoryEntity> = emptyList(),
     onCategorySearch: (String) -> Unit = {},
-    onCategorizeSingle: suspend (String, MpesaSmsEntity, Boolean) -> Unit = { _, _, _ -> },
-    onCategorizeBulk: suspend (String, Set<Any>, Boolean) -> Unit = { _, _, _ -> },
+    onCategorySelected: (Long) -> Unit = {},
+    onCreateCustomSubCategory: suspend (Long, String) -> SubCategoryEntity = { _, _ -> throw IllegalStateException("Custom subcategory creator not provided") },
+    onGetCategory: suspend (Long) -> CategoryEntity = { throw IllegalStateException("Category lookup not provided") },
+    onGetSubCategory: suspend (Long) -> SubCategoryEntity? = { null },
+    onCategorizeSingle: suspend (String, MpesaSmsEntity, Boolean, Long?) -> Unit = { _, _, _, _ -> },
+    onCategorizeBulk: suspend (String, Set<Any>, Boolean, Long?) -> Unit = { _, _, _, _ -> },
     onCategorizationComplete: () -> Unit = {}
 ) {
     val splitBudgetYearMonth = budget.yearMonth.split("-")
@@ -300,7 +326,12 @@ fun DailyUsageScreenContent(
                 onLoadUncategorized = onLoadUncategorized,
                 onIgnoreUncategorized = onIgnoreUncategorized,
                 selectableCategories = selectableCategories,
+                selectableSubCategories = selectableSubCategories,
                 onCategorySearch = onCategorySearch,
+                onCategorySelected = onCategorySelected,
+                onCreateCustomSubCategory = onCreateCustomSubCategory,
+                onGetCategory = onGetCategory,
+                onGetSubCategory = onGetSubCategory,
                 onCategorizeSingle = onCategorizeSingle,
                 onCategorizeBulk = onCategorizeBulk,
                 onCategorizationComplete = onCategorizationComplete
@@ -584,6 +615,7 @@ private fun DayAmountSummary(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun SelectedDayTransactionsCard(
     selectedDate: LocalDate,
@@ -593,9 +625,14 @@ private fun SelectedDayTransactionsCard(
     onLoadUncategorized: () -> Unit,
     onIgnoreUncategorized: (MpesaSmsEntity) -> Unit,
     selectableCategories: List<CategoryEntity>,
+    selectableSubCategories: List<SubCategoryEntity>,
     onCategorySearch: (String) -> Unit,
-    onCategorizeSingle: suspend (String, MpesaSmsEntity, Boolean) -> Unit,
-    onCategorizeBulk: suspend (String, Set<Any>, Boolean) -> Unit,
+    onCategorySelected: (Long) -> Unit,
+    onCreateCustomSubCategory: suspend (Long, String) -> SubCategoryEntity,
+    onGetCategory: suspend (Long) -> CategoryEntity,
+    onGetSubCategory: suspend (Long) -> SubCategoryEntity?,
+    onCategorizeSingle: suspend (String, MpesaSmsEntity, Boolean, Long?) -> Unit,
+    onCategorizeBulk: suspend (String, Set<Any>, Boolean, Long?) -> Unit,
     onCategorizationComplete: () -> Unit
 ) {
     var selectedFilter by remember(selectedDate) {
@@ -605,10 +642,32 @@ private fun SelectedDayTransactionsCard(
     var smsForCategorization by remember(selectedDate) {
         mutableStateOf(emptyList<MpesaSmsEntity>())
     }
+    var pendingIgnoreSms by remember(selectedDate) { mutableStateOf<MpesaSmsEntity?>(null) }
+    val ignoreSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val visibleItemCount = when (selectedFilter) {
         TransactionFilter.CATEGORIZED -> transactions.size
         TransactionFilter.UNCATEGORIZED -> uncategorizedTransactions.size
         TransactionFilter.ALL -> transactions.size + uncategorizedTransactions.size
+    }
+    val timelineItems = remember(transactions, uncategorizedTransactions) {
+        buildList {
+            addAll(
+                transactions.map { transactionItem ->
+                    DayTimelineItem.Categorized(
+                        item = transactionItem,
+                        sortKeyMillis = transactionItem.transaction.happenedAtMillis(),
+                    )
+                }
+            )
+            addAll(
+                uncategorizedTransactions.map { sms ->
+                    DayTimelineItem.Uncategorized(
+                        item = sms,
+                        sortKeyMillis = sms.dateTime,
+                    )
+                }
+            )
+        }.sortedByDescending { it.sortKeyMillis }
     }
 
     Card(modifier = Modifier.fillMaxWidth()) {
@@ -678,63 +737,134 @@ private fun SelectedDayTransactionsCard(
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             } else {
-                if (selectedFilter != TransactionFilter.UNCATEGORIZED) {
-                    transactions.forEach { transactionItem ->
-                        TransactionTile(
-                            transactionItem = transactionItem,
-                            modifier = Modifier.padding(vertical = 4.dp)
-                        )
-                    }
-                }
-                if (selectedFilter != TransactionFilter.CATEGORIZED) {
-                    if (selectedSmsIds.isEmpty()) {
-                        Text(
-                            text = "Tap a transaction for options • Hold to select multiple",
-                            modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    } else {
-                        Row(
-                            modifier = Modifier.fillMaxWidth().padding(bottom = 6.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Text(
-                                text = "${selectedSmsIds.size} selected",
-                                modifier = Modifier.weight(1f),
-                                style = MaterialTheme.typography.labelLarge,
-                                color = MaterialTheme.colorScheme.tertiary
-                            )
-                            TextButton(onClick = { selectedSmsIds = emptySet() }) {
-                                Text("Clear")
-                            }
-                            TextButton(
-                                onClick = {
-                                    smsForCategorization = uncategorizedTransactions.filter {
-                                        it.id in selectedSmsIds
-                                    }
-                                }
-                            ) {
-                                Text("Categorize selected")
+                when (selectedFilter) {
+                    TransactionFilter.ALL -> {
+                        timelineItems.forEach { timelineItem ->
+                            when (timelineItem) {
+                                is DayTimelineItem.Categorized -> TransactionTile(
+                                    transactionItem = timelineItem.item,
+                                    onGetCategory = onGetCategory,
+                                    onGetSubCategory = onGetSubCategory,
+                                    modifier = Modifier.padding(vertical = 4.dp)
+                                )
+                                is DayTimelineItem.Uncategorized -> UncategorizedTransactionTile(
+                                    sms = timelineItem.item,
+                                    isSelected = timelineItem.item.id in selectedSmsIds,
+                                    isSelectionMode = selectedSmsIds.isNotEmpty(),
+                                    onSelectionChange = { isSelected ->
+                                        selectedSmsIds = if (isSelected) {
+                                            selectedSmsIds + timelineItem.item.id
+                                        } else {
+                                            selectedSmsIds - timelineItem.item.id
+                                        }
+                                    },
+                                    onCategorize = { smsForCategorization = listOf(timelineItem.item) },
+                                    onIgnore = { pendingIgnoreSms = timelineItem.item },
+                                    modifier = Modifier.padding(vertical = 4.dp)
+                                )
                             }
                         }
                     }
-                    uncategorizedTransactions.forEach { sms ->
-                        UncategorizedTransactionTile(
-                            sms = sms,
-                            isSelected = sms.id in selectedSmsIds,
-                            isSelectionMode = selectedSmsIds.isNotEmpty(),
-                            onSelectionChange = { isSelected ->
-                                selectedSmsIds = if (isSelected) {
-                                    selectedSmsIds + sms.id
-                                } else {
-                                    selectedSmsIds - sms.id
+                    TransactionFilter.CATEGORIZED -> {
+                        transactions.forEach { transactionItem ->
+                            TransactionTile(
+                                transactionItem = transactionItem,
+                                onGetCategory = onGetCategory,
+                                onGetSubCategory = onGetSubCategory,
+                                modifier = Modifier.padding(vertical = 4.dp)
+                            )
+                        }
+                    }
+                    TransactionFilter.UNCATEGORIZED -> {
+                        if (selectedSmsIds.isEmpty()) {
+                            Text(
+                                text = "Tap a transaction for options • Hold to select multiple",
+                                modifier = Modifier.fillMaxWidth().padding(bottom = 8.dp),
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        } else {
+                            Row(
+                                modifier = Modifier.fillMaxWidth().padding(bottom = 6.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text(
+                                    text = "${selectedSmsIds.size} selected",
+                                    modifier = Modifier.weight(1f),
+                                    style = MaterialTheme.typography.labelLarge,
+                                    color = MaterialTheme.colorScheme.tertiary
+                                )
+                                TextButton(onClick = { selectedSmsIds = emptySet() }) {
+                                    Text("Clear")
                                 }
-                            },
-                            onCategorize = { smsForCategorization = listOf(sms) },
-                            onIgnore = { onIgnoreUncategorized(sms) },
-                            modifier = Modifier.padding(vertical = 4.dp)
-                        )
+                                TextButton(
+                                    onClick = {
+                                        smsForCategorization = uncategorizedTransactions.filter {
+                                            it.id in selectedSmsIds
+                                        }
+                                    }
+                                ) {
+                                    Text("Categorize selected")
+                                }
+                            }
+                        }
+                        uncategorizedTransactions.forEach { sms ->
+                            UncategorizedTransactionTile(
+                                sms = sms,
+                                isSelected = sms.id in selectedSmsIds,
+                                isSelectionMode = selectedSmsIds.isNotEmpty(),
+                                onSelectionChange = { isSelected ->
+                                    selectedSmsIds = if (isSelected) {
+                                        selectedSmsIds + sms.id
+                                    } else {
+                                        selectedSmsIds - sms.id
+                                    }
+                                },
+                                onCategorize = { smsForCategorization = listOf(sms) },
+                                onIgnore = { pendingIgnoreSms = sms },
+                                modifier = Modifier.padding(vertical = 4.dp)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    pendingIgnoreSms?.let { sms ->
+        ModalBottomSheet(
+            onDismissRequest = { pendingIgnoreSms = null },
+            sheetState = ignoreSheetState
+        ) {
+            Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+                Text(
+                    text = "Ignore transaction?",
+                    style = MaterialTheme.typography.headlineSmall
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = "This will remove the uncategorized transaction from Daily Usage.",
+                    style = MaterialTheme.typography.bodyMedium
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(12.dp)
+                ) {
+                    TextButton(
+                        modifier = Modifier.weight(1f),
+                        onClick = { pendingIgnoreSms = null }
+                    ) {
+                        Text("Cancel")
+                    }
+                    Button(
+                        modifier = Modifier.weight(1f),
+                        onClick = {
+                            onIgnoreUncategorized(sms)
+                            pendingIgnoreSms = null
+                        }
+                    ) {
+                        Text("Ignore")
                     }
                 }
             }
@@ -751,16 +881,20 @@ private fun SelectedDayTransactionsCard(
                 getMerchantNameFromSms(firstSms)
             },
             selectableCategories = selectableCategories,
+            selectableSubCategories = selectableSubCategories,
             onCategorySearch = onCategorySearch,
+            onCategorySelected = onCategorySelected,
+            onCreateCustomSubCategory = onCreateCustomSubCategory,
             onDismiss = { smsForCategorization = emptyList() },
-            onSubmit = { categoryName, categorizeSimilar ->
+            onSubmit = { category, subCategory, categorizeSimilar ->
                 if (smsForCategorization.size == 1) {
-                    onCategorizeSingle(categoryName, firstSms, categorizeSimilar)
+                    onCategorizeSingle(category.name, firstSms, categorizeSimilar, subCategory?.id)
                 } else {
                     onCategorizeBulk(
-                        categoryName,
+                        category.name,
                         smsForCategorization.map { it.id }.toSet(),
-                        categorizeSimilar
+                        categorizeSimilar,
+                        subCategory?.id,
                     )
                 }
             },
@@ -774,6 +908,27 @@ private fun SelectedDayTransactionsCard(
     }
 }
 
+private sealed interface DayTimelineItem {
+    val sortKeyMillis: Long
+
+    data class Categorized(
+        val item: DailyTransactionUiModel,
+        override val sortKeyMillis: Long,
+    ) : DayTimelineItem
+
+    data class Uncategorized(
+        val item: MpesaSmsEntity,
+        override val sortKeyMillis: Long,
+    ) : DayTimelineItem
+}
+
+private fun TransactionEntity.happenedAtMillis(): Long {
+    val normalizedTimestamp = timestamp.trim().replace(' ', 'T')
+    return runCatching { LocalDateTime.parse(normalizedTimestamp) }
+        .map { it.toInstant(TimeZone.currentSystemDefault()).toEpochMilliseconds() }
+        .getOrElse { Long.MIN_VALUE }
+}
+
 private enum class TransactionFilter(val label: String) {
     CATEGORIZED("Categorized"),
     UNCATEGORIZED("Uncategorized"),
@@ -783,10 +938,32 @@ private enum class TransactionFilter(val label: String) {
 @Composable
 private fun TransactionTile(
     transactionItem: DailyTransactionUiModel,
+    onGetCategory: suspend (Long) -> CategoryEntity,
+    onGetSubCategory: suspend (Long) -> SubCategoryEntity?,
     modifier: Modifier = Modifier
 ) {
     val transaction = transactionItem.transaction
     val merchantName = transactionItem.merchantName
+    var category by remember { mutableStateOf<CategoryEntity?>(null) }
+    var subCategory by remember { mutableStateOf<SubCategoryEntity?>(null) }
+    val resolvedCategory = category
+    val circleColor = when {
+        resolvedCategory != null && subCategory != null ->
+            subCategory!!.displayColor(resolvedCategory, false)
+        resolvedCategory != null -> resolvedCategory.displayColor(false)
+        else -> MaterialTheme.colorScheme.primaryContainer
+    }
+    val circleIcon = when {
+        resolvedCategory != null && subCategory != null ->
+            subCategory!!.displayIcon(resolvedCategory)
+        resolvedCategory != null -> resolvedCategory.displayIcon()
+        else -> Icons.Default.Category
+    }
+
+    androidx.compose.runtime.LaunchedEffect(transaction.id) {
+        category = onGetCategory(transaction.categoryId)
+        subCategory = transaction.subCategoryId?.let { onGetSubCategory(it) }
+    }
 
     Card(
         modifier = modifier.fillMaxWidth(),
@@ -801,19 +978,14 @@ private fun TransactionTile(
             Box(
                 modifier = Modifier
                     .size(40.dp)
-                    .background(MaterialTheme.colorScheme.primaryContainer, CircleShape),
+                    .background(circleColor, CircleShape),
                 contentAlignment = Alignment.Center
             ) {
-                Text(
-                    text = merchantName
-                        .trim()
-                        .firstOrNull()
-                        ?.uppercaseChar()
-                        ?.toString()
-                        ?: "T",
-                    style = MaterialTheme.typography.titleMedium,
-                    color = MaterialTheme.colorScheme.primary,
-                    fontWeight = FontWeight.Bold
+                Icon(
+                    imageVector = circleIcon,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onPrimary,
+                    modifier = Modifier.size(20.dp)
                 )
             }
             Spacer(modifier = Modifier.width(12.dp))

--- a/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/ui/DailyUsageScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/ui/DailyUsageScreenViewModel.kt
@@ -3,11 +3,14 @@ package co.ke.foxlysoft.budgetgain.ui
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import co.ke.foxlysoft.budgetgain.database.BudgetEntity
+import co.ke.foxlysoft.budgetgain.database.CategoryEntity
 import co.ke.foxlysoft.budgetgain.database.TransactionEntity
+import co.ke.foxlysoft.budgetgain.database.SubCategoryEntity
 import co.ke.foxlysoft.budgetgain.database.MpesaSmsEntity
 import co.ke.foxlysoft.budgetgain.my_calendar.DayStatus
 import co.ke.foxlysoft.budgetgain.repos.AccountRepository
 import co.ke.foxlysoft.budgetgain.repos.BudgetRepository
+import co.ke.foxlysoft.budgetgain.repos.CategoryRepository
 import co.ke.foxlysoft.budgetgain.repos.SettingsRepository
 import co.ke.foxlysoft.budgetgain.repos.MpesaSmsRepository
 import co.ke.foxlysoft.budgetgain.repos.TransactionRepository
@@ -16,6 +19,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atStartOfDayIn
@@ -23,12 +27,14 @@ import kotlinx.datetime.number
 import kotlinx.datetime.plus
 import kotlinx.datetime.todayIn
 import kotlinx.datetime.yearMonth
+import kotlinx.datetime.toInstant
 import kotlin.time.Clock
 
 class DailyUsageScreenViewModel (
     private val budgetRepository: BudgetRepository,
     private val transactionsRepository: TransactionRepository,
     private val accountRepository: AccountRepository,
+    private val categoryRepository: CategoryRepository,
     private val settingsRepository: SettingsRepository,
     private val mpesaSmsRepository: MpesaSmsRepository
 ): ViewModel() {
@@ -167,7 +173,9 @@ class DailyUsageScreenViewModel (
             }
 
             transactionItemsByDate = transactionsByDate.mapValues { (_, dailyTransactions) ->
-                dailyTransactions.map { transaction ->
+                dailyTransactions
+                    .sortedByDescending { transaction -> transaction.happenedAtMillis() }
+                    .map { transaction ->
                     DailyTransactionUiModel(
                         transaction = transaction,
                         merchantName = merchantNameCache[transaction.creditAccountId]
@@ -276,13 +284,71 @@ class DailyUsageScreenViewModel (
     }
 
     fun refreshSelectedDay() {
+        val selectedDate = _selectedDate.value ?: return
+        val budget = _currentBudget.value.takeIf { it.yearMonth.isNotBlank() } ?: return
+
         uncategorizedLoadedDate = null
         loadUncategorizedTransactions()
-        _currentBudget.value
-            .takeIf { it.yearMonth.isNotBlank() }
-            ?.let { budget ->
-                viewModelScope.launch { computeDayStatuses(budget) }
+        viewModelScope.launch {
+            refreshSelectedDayTransactions(selectedDate, budget)
+        }
+    }
+
+    suspend fun getCategory(categoryId: Long): CategoryEntity {
+        return categoryRepository.getCategory(categoryId)
+    }
+
+    suspend fun getSubCategory(subCategoryId: Long): SubCategoryEntity? {
+        return categoryRepository.getSubCategory(subCategoryId)
+    }
+
+    private fun TransactionEntity.happenedAtMillis(): Long {
+        val normalizedTimestamp = timestamp.trim().replace(' ', 'T')
+        return runCatching { LocalDateTime.parse(normalizedTimestamp) }
+            .map { it.toInstant(TimeZone.currentSystemDefault()).toEpochMilliseconds() }
+            .getOrElse { Long.MIN_VALUE }
+    }
+
+    private suspend fun refreshSelectedDayTransactions(selectedDate: LocalDate, budget: BudgetEntity) {
+        val selectedDateKey = selectedDate.toString()
+        val selectedTransactions = transactionsRepository.getBudgetTransactions(budget.id)
+            .filter { transaction ->
+                transaction.timestamp.length >= 10 && transaction.timestamp.substring(0, 10) == selectedDateKey
             }
+            .sortedByDescending { transaction -> transaction.happenedAtMillis() }
+
+        val updatedTransactions = mutableListOf<DailyTransactionUiModel>()
+        for (transaction in selectedTransactions) {
+            val account = runCatching { accountRepository.getAccount(transaction.creditAccountId) }
+                .getOrNull()
+            val merchantName = merchantNameCache.getOrPut(transaction.creditAccountId) {
+                account?.merchantName?.takeIf { it.isNotBlank() }
+                    ?: account?.name?.takeIf { it.isNotBlank() }
+                    ?: UNKNOWN_MERCHANT
+            }
+            updatedTransactions += DailyTransactionUiModel(
+                transaction = transaction,
+                merchantName = merchantName
+            )
+        }
+
+        transactionItemsByDate = transactionItemsByDate + (selectedDate to updatedTransactions)
+        _selectedDayTransactions.value = updatedTransactions
+
+        val usedAmount = updatedTransactions.sumOf { it.transaction.amount }
+        val previousSelectedDayStatus = _selectedDayStatus.value
+        val updatedSelectedDayStatus = previousSelectedDayStatus.copy(
+            usedAmount = usedAmount,
+            isUsed = usedAmount > 0,
+            isOverUsed = usedAmount > _dailyUsageInCents.value,
+            overUsedAmount = (usedAmount - _dailyUsageInCents.value).coerceAtLeast(0),
+            carriedForwardAmount = (previousSelectedDayStatus.broughtForwardAmount + _dailyUsageInCents.value - usedAmount),
+            isMovedForward = (previousSelectedDayStatus.broughtForwardAmount + _dailyUsageInCents.value - usedAmount) > 0,
+        )
+        _selectedDayStatus.value = updatedSelectedDayStatus
+        _dayStatus.value = _dayStatus.value.toMutableMap().apply {
+            put(selectedDate, updatedSelectedDayStatus)
+        }
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/ui/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/ui/HomeScreen.kt
@@ -2,6 +2,7 @@ package co.ke.foxlysoft.budgetgain.ui
 
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -15,6 +16,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.selection.selectable
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -582,6 +584,17 @@ fun CategoryItem(category: CategoryEntity,
                     .padding(horizontal = 8.dp, vertical = 2.dp), // Adjust padding if needed
                 verticalAlignment = Alignment.CenterVertically
             ) {
+                Box(
+                    modifier = Modifier.padding(end = 8.dp)
+                        .background(category.displayColor(isSystemInDarkTheme()), shape = CircleShape),
+                ) {
+                    Icon(
+                        imageVector = category.displayIcon(),
+                        contentDescription = null,
+                        tint = MaterialTheme.colorScheme.onPrimary,
+                        modifier = Modifier.padding(2.dp)
+                    )
+                }
                 Text(
                     text = category.name,
                     modifier = Modifier
@@ -593,7 +606,7 @@ fun CategoryItem(category: CategoryEntity,
                 )
                 Text (
                     text = centsToString(category.amount - category.spentAmount),
-                    style = MaterialTheme.typography.titleMedium
+                    style = MaterialTheme.typography.titleSmall
                 )
                 IconButton(onClick = {
                     isShowingDetails = !isShowingDetails

--- a/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/ui/SpendScreen.kt
+++ b/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/ui/SpendScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.zIndex
 import budgetgain.composeapp.generated.resources.Res
 import budgetgain.composeapp.generated.resources.ic_attach_file
 import co.ke.foxlysoft.budgetgain.shared.getLastCopiedText
+import co.ke.foxlysoft.budgetgain.database.SubCategoryEntity
 import co.ke.foxlysoft.budgetgain.ui.components.BGainOutlineField
 import co.ke.foxlysoft.budgetgain.utils.ErrorStatus
 import co.ke.foxlysoft.budgetgain.utils.MpesaSmsTypes
@@ -69,6 +70,9 @@ fun SpendScreen(
     var merchantAutoCompleteExpanded by remember { mutableStateOf(false) }
 
     val selectableCategories by spendScreenViewModel.selectableCategories.collectAsState()
+    val selectableSubCategories by spendScreenViewModel.selectableSubCategories.collectAsState()
+    var selectedSubCategory by remember { mutableStateOf<SubCategoryEntity?>(null) }
+    var subCategoryExpanded by remember { mutableStateOf(false) }
     var categoryName by remember { mutableStateOf(category?.name ?: "") }
     var categoryNameErrorStatus by remember { mutableStateOf(ErrorStatus(isError = false)) }
     var categoryAutoCompleteExpanded by remember { mutableStateOf(false) }
@@ -78,6 +82,7 @@ fun SpendScreen(
         if (categoryName.isEmpty() && category != null) {
             categoryName = category.name
         }
+        if (selectedSubCategory?.categoryId != category?.id) selectedSubCategory = null
     }
 
     // Preload categories on screen open
@@ -272,6 +277,51 @@ fun SpendScreen(
                         }
                     }
                 }
+                if (selectableSubCategories.isNotEmpty()) {
+                    BGainOutlineField(
+                        modifier = Modifier.fillMaxWidth(),
+                        labelStr = "Subcategory (optional)",
+                        Value = selectedSubCategory?.name ?: "",
+                        errorStatus = ErrorStatus(isError = false),
+                        trailingIcon = {
+                            IconButton(onClick = { subCategoryExpanded = !subCategoryExpanded }) {
+                                Icon(Icons.Default.ArrowDropDown, contentDescription = "Show subcategories")
+                            }
+                        },
+                        onValueChange = {},
+                    )
+                    Box {
+                        if (subCategoryExpanded) {
+                            Popup(onDismissRequest = { subCategoryExpanded = false }) {
+                                Card(
+                                    modifier = Modifier.fillMaxWidth().heightIn(max = 240.dp)
+                                        .padding(horizontal = 32.dp).zIndex(1f)
+                                ) {
+                                    LazyColumn {
+                                        item {
+                                            TextButton(
+                                                modifier = Modifier.fillMaxWidth(),
+                                                onClick = {
+                                                    selectedSubCategory = null
+                                                    subCategoryExpanded = false
+                                                },
+                                            ) { Text("No subcategory") }
+                                        }
+                                        items(selectableSubCategories) { subCategory ->
+                                            TextButton(
+                                                modifier = Modifier.fillMaxWidth(),
+                                                onClick = {
+                                                    selectedSubCategory = subCategory
+                                                    subCategoryExpanded = false
+                                                },
+                                            ) { Text(subCategory.name) }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
                 BGainOutlineField(
                     modifier = Modifier
                         .fillMaxWidth(),
@@ -430,7 +480,8 @@ fun SpendScreen(
                                 merchant,
                                 description,
                                 amountToCents(amount),
-                                fullDateTime
+                                fullDateTime,
+                                selectedSubCategory?.id,
                             )
                         } catch (e: Exception) {
                             Logger.e("Error spending", e)

--- a/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/ui/SpendScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/ui/SpendScreenViewModel.kt
@@ -7,6 +7,7 @@ import co.ke.foxlysoft.budgetgain.database.AccountEntity
 import co.ke.foxlysoft.budgetgain.database.AccountType
 import co.ke.foxlysoft.budgetgain.database.CategoryEntity
 import co.ke.foxlysoft.budgetgain.database.TransactionEntity
+import co.ke.foxlysoft.budgetgain.database.SubCategoryEntity
 import co.ke.foxlysoft.budgetgain.repos.AccountRepository
 import co.ke.foxlysoft.budgetgain.repos.BudgetRepository
 import co.ke.foxlysoft.budgetgain.repos.CategoryRepository
@@ -51,6 +52,13 @@ class SpendScreenViewModel(
 
     private val _selectableCategories = MutableStateFlow<List<CategoryEntity>>(emptyList())
     val selectableCategories: StateFlow<List<CategoryEntity>> = _selectableCategories
+
+    val selectableSubCategories: StateFlow<List<SubCategoryEntity>> = categorySelection.categoryId
+        .flatMapLatest { selectedId ->
+            if (selectedId == null) flowOf(emptyList())
+            else categoryRepository.getSubCategoriesFlow(selectedId)
+        }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     private val _merchantAccounts = MutableStateFlow<List<AccountEntity>>(emptyList())
     val merchantAccounts: StateFlow<List<AccountEntity>> = _merchantAccounts
@@ -97,7 +105,16 @@ class SpendScreenViewModel(
     }
 
     @Transaction
-    fun spend(onComplete:() -> Unit , onError: (Throwable) -> Unit, ref: String, merchantName: String, description: String, amount: Long, timestamp: String) {
+    fun spend(
+        onComplete: () -> Unit,
+        onError: (Throwable) -> Unit,
+        ref: String,
+        merchantName: String,
+        description: String,
+        amount: Long,
+        timestamp: String,
+        subCategoryId: Long? = null,
+    ) {
         viewModelScope.launch {
             try {
                 withContext(Dispatchers.IO) {
@@ -142,6 +159,7 @@ class SpendScreenViewModel(
                         debitAccountId = budgetAccount.id,
                         creditAccountId = merchantAccount!!.id,
                         categoryId = currentCategoryProxy.id,
+                        subCategoryId = subCategoryId,
                         amount = amount,
                         timestamp = timestamp,
                     )

--- a/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/ui/UncategorizedMpesaSmsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/ui/UncategorizedMpesaSmsScreen.kt
@@ -13,6 +13,9 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items as gridItems
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
@@ -23,9 +26,11 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -33,6 +38,7 @@ import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -53,6 +59,7 @@ import androidx.compose.ui.zIndex
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import co.ke.foxlysoft.budgetgain.database.MpesaSmsEntity
 import co.ke.foxlysoft.budgetgain.database.CategoryEntity
+import co.ke.foxlysoft.budgetgain.database.SubCategoryEntity
 import co.ke.foxlysoft.budgetgain.ui.components.BGPaginatedList
 import co.ke.foxlysoft.budgetgain.ui.components.BGainOutlineField
 import co.ke.foxlysoft.budgetgain.ui.components.BGainPaginationController
@@ -75,6 +82,7 @@ fun UncategorizedMpesaSmsScreen(
     val coroutineScope = rememberCoroutineScope()
 
     val selectableCategories by uncategorizedMpesaSmsScreenViewModel.selectableCategories.collectAsStateWithLifecycle()
+    val selectableSubCategories by uncategorizedMpesaSmsScreenViewModel.selectableSubCategories.collectAsStateWithLifecycle()
     val smsToCategorize = remember { mutableStateOf<MpesaSmsEntity?>(null) }
     val selectedSmsIds = remember { mutableStateOf<Set<Long>>(emptySet()) }
     var isMultiSelectMode by remember { mutableStateOf(false) }
@@ -136,20 +144,25 @@ fun UncategorizedMpesaSmsScreen(
             itemCount = if (isBulkMode) selectedSmsIds.value.size else 1,
             merchantLabel = merchantLabel,
             selectableCategories = selectableCategories,
+            selectableSubCategories = selectableSubCategories,
             onCategorySearch = uncategorizedMpesaSmsScreenViewModel::updateCategorySearchQuery,
+            onCategorySelected = uncategorizedMpesaSmsScreenViewModel::loadSubCategories,
+            onCreateCustomSubCategory = uncategorizedMpesaSmsScreenViewModel::createCustomSubCategory,
             onDismiss = { showBottomSheet = false },
-            onSubmit = { selectedCategory, categorizeSimilar ->
+            onSubmit = { selectedCategory, selectedSubCategory, categorizeSimilar ->
                 if (isBulkMode) {
                     uncategorizedMpesaSmsScreenViewModel.categorizeBulkSms(
-                        selectedCategory,
+                        selectedCategory.name,
                         selectedSmsIds.value,
-                        categorizeSimilar
+                        categorizeSimilar,
+                        selectedSubCategory?.id,
                     )
                 } else {
                     uncategorizedMpesaSmsScreenViewModel.categorizeSms(
-                        selectedCategory,
+                        selectedCategory.name,
                         smsToCategorize.value!!,
-                        categorizeSimilar
+                        categorizeSimilar,
+                        selectedSubCategory?.id,
                     )
                 }
             },
@@ -172,20 +185,26 @@ fun CategorizationBottomSheet(
     itemCount: Int,
     merchantLabel: String,
     selectableCategories: List<CategoryEntity>,
+    selectableSubCategories: List<SubCategoryEntity>,
     onCategorySearch: (String) -> Unit,
+    onCategorySelected: (Long) -> Unit,
+    onCreateCustomSubCategory: suspend (Long, String) -> SubCategoryEntity,
     onDismiss: () -> Unit,
-    onSubmit: suspend (categoryName: String, categorizeSimilar: Boolean) -> Unit,
+    onSubmit: suspend (category: CategoryEntity, subCategory: SubCategoryEntity?, categorizeSimilar: Boolean) -> Unit,
     onSuccess: () -> Unit,
     onError: (String) -> Unit
 ) {
     val coroutineScope = rememberCoroutineScope()
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    var categoryName by remember { mutableStateOf("") }
-    var categoryError by remember { mutableStateOf(ErrorStatus(false)) }
-    var isCategoryMenuExpanded by remember { mutableStateOf(false) }
+    var selectedCategory by remember { mutableStateOf<CategoryEntity?>(null) }
+    var selectedSubCategory by remember { mutableStateOf<SubCategoryEntity?>(null) }
+    var pickingSubCategory by remember { mutableStateOf(false) }
     var categorizeSimilar by remember { mutableStateOf(true) }
     var isSubmitting by remember { mutableStateOf(false) }
     var submissionError by remember { mutableStateOf<String?>(null) }
+    var customSubCategoryName by remember { mutableStateOf("") }
+    var isCreatingCustomSubCategory by remember { mutableStateOf(false) }
+    var showCustomSubCategoryDialog by remember { mutableStateOf(false) }
 
     LaunchedEffect(Unit) { onCategorySearch("") }
 
@@ -196,52 +215,145 @@ fun CategorizationBottomSheet(
                 style = MaterialTheme.typography.headlineSmall
             )
             Spacer(modifier = Modifier.height(8.dp))
-            BGainOutlineField(
+            Row(
                 modifier = Modifier.fillMaxWidth(),
-                labelStr = "Category",
-                Value = categoryName,
-                errorStatus = categoryError,
-                trailingIcon = {
-                    IconButton(onClick = {
-                        onCategorySearch(categoryName)
-                        isCategoryMenuExpanded = !isCategoryMenuExpanded
-                    }) {
-                        Icon(Icons.Default.ArrowDropDown, contentDescription = "Show categories")
-                    }
-                },
-                onValueChange = { value ->
-                    categoryName = value
-                    categoryError = ErrorStatus(false)
-                    onCategorySearch(value)
-                    isCategoryMenuExpanded = true
-                },
-                validator = {}
-            )
-            Box {
-                if (isCategoryMenuExpanded && selectableCategories.isNotEmpty()) {
-                    Popup(onDismissRequest = { isCategoryMenuExpanded = false }) {
-                        Card(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .heightIn(max = 240.dp)
-                                .padding(horizontal = 32.dp)
-                                .zIndex(1f)
-                        ) {
-                            LazyColumn {
-                                items(selectableCategories) { category ->
-                                    TextButton(
-                                        modifier = Modifier.fillMaxWidth(),
-                                        onClick = {
-                                            categoryName = category.name
-                                            categoryError = ErrorStatus(false)
-                                            isCategoryMenuExpanded = false
-                                        }
-                                    ) { Text(category.name) }
-                                }
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.Center,
+            ) {
+                FilterChip(
+                    selected = !pickingSubCategory,
+                    onClick = { pickingSubCategory = false },
+                    leadingIcon = selectedCategory?.let { category ->
+                        {
+                            Icon(
+                                imageVector = category.displayIcon(),
+                                contentDescription = null,
+                            )
+                        }
+                    },
+                    label = { Text(selectedCategory?.name ?: "Category") },
+                )
+                Text("/", modifier = Modifier.padding(horizontal = 10.dp), style = MaterialTheme.typography.titleLarge)
+                FilterChip(
+                    selected = pickingSubCategory,
+                    enabled = selectedCategory != null,
+                    onClick = { if (selectedCategory != null) pickingSubCategory = true },
+                    leadingIcon = selectedSubCategory?.let { subCategory ->
+                        selectedCategory?.let { category ->
+                            {
+                                Icon(
+                                    imageVector = subCategory.displayIcon(category),
+                                    contentDescription = null,
+                                )
                             }
                         }
+                    },
+                    label = { Text(selectedSubCategory?.name ?: "Subcategory") },
+                )
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = if (pickingSubCategory) "Choose a subcategory" else "Choose a category",
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            val pickerItems: List<Any> = if (pickingSubCategory) selectableSubCategories else selectableCategories
+            if (pickingSubCategory && pickerItems.isEmpty()) {
+                Text(
+                    "No subcategories available. You can categorize using ${selectedCategory?.name} only.",
+                    modifier = Modifier.padding(vertical = 24.dp),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            } else {
+                LazyVerticalGrid(
+                    columns = GridCells.Fixed(2),
+                    modifier = Modifier.fillMaxWidth().heightIn(max = 260.dp),
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    gridItems(pickerItems, key = {
+                        when (it) {
+                            is CategoryEntity -> "category-${it.id}"
+                            is SubCategoryEntity -> "subcategory-${it.id}"
+                            else -> it.hashCode().toString()
+                        }
+                    }) { item ->
+                        val label = when (item) {
+                            is CategoryEntity -> item.name
+                            is SubCategoryEntity -> item.name
+                            else -> ""
+                        }
+                        val selected = when (item) {
+                            is CategoryEntity -> selectedCategory?.id == item.id
+                            is SubCategoryEntity -> selectedSubCategory?.id == item.id
+                            else -> false
+                        }
+                        FilterChip(
+                            selected = selected,
+                            onClick = {
+                                when (item) {
+                                    is CategoryEntity -> {
+                                        if (selectedCategory?.id != item.id) selectedSubCategory = null
+                                        selectedCategory = item
+                                        onCategorySelected(item.id)
+                                        pickingSubCategory = true
+                                    }
+                                    is SubCategoryEntity -> selectedSubCategory = item
+                                }
+                            },
+                            label = { Text(label) },
+                        )
                     }
                 }
+            }
+            if (pickingSubCategory && selectedCategory != null) {
+                Spacer(modifier = Modifier.height(12.dp))
+                FilterChip(
+                    selected = false,
+                    onClick = { showCustomSubCategoryDialog = true },
+                    label = { Text("Add subcategory") },
+                )
+            }
+            if (showCustomSubCategoryDialog && selectedCategory != null) {
+                AlertDialog(
+                    onDismissRequest = { showCustomSubCategoryDialog = false },
+                    title = { Text("Add subcategory") },
+                    text = {
+                        OutlinedTextField(
+                            value = customSubCategoryName,
+                            onValueChange = { customSubCategoryName = it },
+                            modifier = Modifier.fillMaxWidth(),
+                            label = { Text("Subcategory name") },
+                            singleLine = true,
+                        )
+                    },
+                    confirmButton = {
+                        TextButton(
+                            enabled = customSubCategoryName.isNotBlank() && !isCreatingCustomSubCategory,
+                            onClick = {
+                                val category = selectedCategory ?: return@TextButton
+                                coroutineScope.launch {
+                                    isCreatingCustomSubCategory = true
+                                    try {
+                                        val created = onCreateCustomSubCategory(category.id, customSubCategoryName.trim())
+                                        selectedSubCategory = created
+                                        customSubCategoryName = ""
+                                        showCustomSubCategoryDialog = false
+                                    } finally {
+                                        isCreatingCustomSubCategory = false
+                                    }
+                                }
+                            }
+                        ) {
+                            Text(if (isCreatingCustomSubCategory) "Adding..." else "Add")
+                        }
+                    },
+                    dismissButton = {
+                        TextButton(onClick = { showCustomSubCategoryDialog = false }) {
+                            Text("Cancel")
+                        }
+                    }
+                )
             }
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -273,15 +385,12 @@ fun CategorizationBottomSheet(
                 modifier = Modifier.fillMaxWidth(),
                 enabled = !isSubmitting,
                 onClick = {
-                    if (selectableCategories.none { it.name == categoryName }) {
-                        categoryError = ErrorStatus(true, "Select a category from the list")
-                        return@Button
-                    }
+                    val category = selectedCategory ?: return@Button
                     coroutineScope.launch {
                         isSubmitting = true
                         submissionError = null
                         try {
-                            onSubmit(categoryName, categorizeSimilar)
+                            onSubmit(category, selectedSubCategory, categorizeSimilar)
                             onSuccess()
                         } catch (error: Exception) {
                             val message = error.message ?: "Unable to categorize transactions"
@@ -307,6 +416,7 @@ fun CategorizationBottomSheet(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun UncategorizedMpesaSmsContent(
     onGetItems: suspend (Int, Int) -> List<MpesaSmsEntity>,
@@ -323,6 +433,9 @@ fun UncategorizedMpesaSmsContent(
     onCategorizeSelected: () -> Unit = {},
     onOpenSnackbar: (String) -> Unit = {}
 ) {
+    var pendingIgnoreSms by remember { mutableStateOf<MpesaSmsEntity?>(null) }
+    val ignoreSheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
     Column {
         Text(text = "Uncategorized MPESA sms", style = MaterialTheme.typography.headlineMedium)
         Spacer(modifier = Modifier.height(8.dp))
@@ -397,6 +510,7 @@ fun UncategorizedMpesaSmsContent(
                     onLongPress = { onEnterMultiSelectMode(sms.id) },
                     onToggleSelection = { onToggleSelection(sms.id) },
                     onIgnoreSms = onIgnoreSms,
+                    onRequestIgnore = { pendingIgnoreSms = it },
                     onCategorize = onCategorize
                 )
             },
@@ -405,6 +519,46 @@ fun UncategorizedMpesaSmsContent(
             },
             controller = paginationController,
         )
+
+        pendingIgnoreSms?.let { sms ->
+            ModalBottomSheet(
+                onDismissRequest = { pendingIgnoreSms = null },
+                sheetState = ignoreSheetState
+            ) {
+                Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+                    Text(
+                        text = "Ignore SMS?",
+                        style = MaterialTheme.typography.headlineSmall
+                    )
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = "This will remove SMS #${sms.ref} from the uncategorized list.",
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        TextButton(
+                            modifier = Modifier.weight(1f),
+                            onClick = { pendingIgnoreSms = null }
+                        ) {
+                            Text("Cancel")
+                        }
+                        Button(
+                            modifier = Modifier.weight(1f),
+                            onClick = {
+                                onIgnoreSms(sms)
+                                pendingIgnoreSms = null
+                            }
+                        ) {
+                            Text("Ignore")
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 
@@ -416,6 +570,7 @@ fun SmsItem(
     onLongPress: () -> Unit = {},
     onToggleSelection: () -> Unit = {},
     onIgnoreSms: (MpesaSmsEntity) -> Unit = {},
+    onRequestIgnore: (MpesaSmsEntity) -> Unit = {},
     onCategorize: (MpesaSmsEntity) -> Unit = {}
 ) {
     // State to track the expanded state of the menu
@@ -506,7 +661,7 @@ fun SmsItem(
                                 Text("Categorize")
                             })
                         DropdownMenuItem(onClick = {
-                            onIgnoreSms(sms)
+                            onRequestIgnore(sms)
                             menuExpanded = false
                         },
                             text = {

--- a/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/ui/UncategorizedMpesaSmsScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/co/ke/foxlysoft/budgetgain/ui/UncategorizedMpesaSmsScreenViewModel.kt
@@ -9,8 +9,10 @@ import co.ke.foxlysoft.budgetgain.database.AccountEntity
 import co.ke.foxlysoft.budgetgain.database.AccountType
 import co.ke.foxlysoft.budgetgain.database.BudgetEntity
 import co.ke.foxlysoft.budgetgain.database.CategoryEntity
+import co.ke.foxlysoft.budgetgain.database.CommonCategoryCatalog
 import co.ke.foxlysoft.budgetgain.database.MpesaSmsEntity
 import co.ke.foxlysoft.budgetgain.database.TransactionEntity
+import co.ke.foxlysoft.budgetgain.database.SubCategoryEntity
 import co.ke.foxlysoft.budgetgain.repos.AccountRepository
 import co.ke.foxlysoft.budgetgain.repos.BudgetRepository
 import co.ke.foxlysoft.budgetgain.repos.CategoryRepository
@@ -67,6 +69,9 @@ class UncategorizedMpesaSmsScreenViewModel(
     private val _selectableCategories = MutableStateFlow<List<CategoryEntity>>(emptyList())
     val selectableCategories: StateFlow<List<CategoryEntity>> = _selectableCategories
 
+    private val _selectableSubCategories = MutableStateFlow<List<SubCategoryEntity>>(emptyList())
+    val selectableSubCategories: StateFlow<List<SubCategoryEntity>> = _selectableSubCategories
+
     private val _search = MutableStateFlow("")
     val search: StateFlow<String> = _search.asStateFlow()
 
@@ -122,6 +127,26 @@ class UncategorizedMpesaSmsScreenViewModel(
     }
 
     private var _searchJob: Job? = null
+    private var subCategoryJob: Job? = null
+
+    fun loadSubCategories(categoryId: Long) {
+        subCategoryJob?.cancel()
+        subCategoryJob = viewModelScope.launch {
+            categoryRepository.getSubCategoriesFlow(categoryId).collectLatest {
+                _selectableSubCategories.value = it
+            }
+        }
+    }
+
+    suspend fun createCustomSubCategory(categoryId: Long, name: String): SubCategoryEntity {
+        val subCategory = SubCategoryEntity(
+            categoryId = categoryId,
+            catalogKey = CommonCategoryCatalog.normalizedKey(name),
+            name = name,
+        )
+        val id = categoryRepository.upsertSubCategory(subCategory)
+        return subCategory.copy(id = id)
+    }
     // Function to update the search query
     fun updateCategorySearchQuery(query: String) {
         _searchJob?.cancel()
@@ -142,7 +167,7 @@ class UncategorizedMpesaSmsScreenViewModel(
         }
     }
 
-    private suspend fun categorizeSingleSms(categoryName: String, smsId: Long) {
+    private suspend fun categorizeSingleSms(categoryName: String, smsId: Long, subCategoryId: Long? = null) {
         val smsToCategorize = mpesaSmsRepository.getUncategorizedMpesaSmsById(smsId) ?: return
 
         transactionRepository.getByRef(smsToCategorize.ref)?.let { existingTransaction ->
@@ -198,6 +223,7 @@ class UncategorizedMpesaSmsScreenViewModel(
             debitAccountId = budgetAccount.id,
             creditAccountId = merchantAccount!!.id,
             categoryId = category.id,
+            subCategoryId = subCategoryId,
             amount = smsToCategorize.amount,
             timestamp = transactionTimestamp,
         )
@@ -238,7 +264,12 @@ class UncategorizedMpesaSmsScreenViewModel(
         mpesaSmsRepository.ignoreMpesaSms(smsToIgnore.id)
     }
 
-    suspend fun categorizeSms(categoryName: String, smsToCategorize: MpesaSmsEntity, shouldCategorizeSimilarByMerchant: Boolean) {
+    suspend fun categorizeSms(
+        categoryName: String,
+        smsToCategorize: MpesaSmsEntity,
+        shouldCategorizeSimilarByMerchant: Boolean,
+        subCategoryId: Long? = null,
+    ) {
         try {
             mpesaSmsRepository.withWriteTransaction {
                 val smsIds = linkedSetOf(smsToCategorize.id)
@@ -254,7 +285,7 @@ class UncategorizedMpesaSmsScreenViewModel(
                     ).map { it.id }
                 }
 
-                smsIds.forEach { categorizeSingleSms(categoryName, it) }
+                smsIds.forEach { categorizeSingleSms(categoryName, it, subCategoryId) }
             }
         } catch (e: Exception) {
             Logger.e("Error categorizing mpesa sms", e)
@@ -262,7 +293,12 @@ class UncategorizedMpesaSmsScreenViewModel(
         }
     }
 
-    suspend fun categorizeBulkSms(categoryName: String, selectedSmsIds: Set<Any>, shouldCategorizeSimilarByMerchant: Boolean) {
+    suspend fun categorizeBulkSms(
+        categoryName: String,
+        selectedSmsIds: Set<Any>,
+        shouldCategorizeSimilarByMerchant: Boolean,
+        subCategoryId: Long? = null,
+    ) {
         try {
             mpesaSmsRepository.withWriteTransaction {
                 val selectedIds = selectedSmsIds.mapNotNull { it as? Long }.toSet()
@@ -285,7 +321,7 @@ class UncategorizedMpesaSmsScreenViewModel(
                 }
 
                 val smsIds = categorizationSmsIds(selectedSms, similarSms)
-                smsIds.forEach { categorizeSingleSms(categoryName, it) }
+                smsIds.forEach { categorizeSingleSms(categoryName, it, subCategoryId) }
             }
         } catch (e: Exception) {
             Logger.e("Error bulk categorizing mpesa sms", e)

--- a/composeApp/src/commonTest/kotlin/co/ke/foxlysoft/budgetgain/database/CommonCategoryCatalogTest.kt
+++ b/composeApp/src/commonTest/kotlin/co/ke/foxlysoft/budgetgain/database/CommonCategoryCatalogTest.kt
@@ -1,0 +1,45 @@
+package co.ke.foxlysoft.budgetgain.database
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class CommonCategoryCatalogTest {
+    @Test
+    fun catalogContainsUniqueStableKeysAndMaterialColors() {
+        assertEquals(9, CommonCategoryCatalog.categories.size)
+        assertEquals(
+            CommonCategoryCatalog.categories.size,
+            CommonCategoryCatalog.categories.map { it.key }.toSet().size,
+        )
+        CommonCategoryCatalog.categories.forEach { category ->
+            assertTrue(category.iconKey.isNotBlank())
+            assertTrue(category.lightColorArgb ushr 24 == 0xFFL)
+            assertTrue(category.darkColorArgb ushr 24 == 0xFFL)
+            assertEquals(
+                category.subCategories.size,
+                category.subCategories.map { it.key }.toSet().size,
+            )
+        }
+        assertNotNull(CommonCategoryCatalog.find("transport")?.subCategories?.find { it.key == "fuel" })
+    }
+
+    @Test
+    fun missingPresentationValuesInheritFromParent() {
+        val parent = CategoryEntity(
+            budgetId = 1,
+            name = "Mobile",
+            amount = 0,
+            spentAmount = 0,
+            iconKey = "smartphone",
+            lightColorArgb = 0xFF0097A7,
+            darkColorArgb = 0xFF4DD0E1,
+        )
+        val child = SubCategoryEntity(categoryId = 1, name = "Airtime")
+
+        assertEquals("smartphone", child.resolvedIconKey(parent))
+        assertEquals(parent.lightColorArgb, child.resolvedColorArgb(parent, false))
+        assertEquals(parent.darkColorArgb, child.resolvedColorArgb(parent, true))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/co/ke/foxlysoft/budgetgain/database/DatabaseMigrationsTest.kt
+++ b/composeApp/src/commonTest/kotlin/co/ke/foxlysoft/budgetgain/database/DatabaseMigrationsTest.kt
@@ -7,7 +7,7 @@ class DatabaseMigrationsTest {
     @Test
     fun migrationPathCoversEveryPersistedSchemaThroughCurrentVersion() {
         assertEquals(
-            listOf(14 to 18, 15 to 18, 16 to 18),
+            listOf(14 to 18, 15 to 18, 16 to 18, 18 to 19),
             APP_DATABASE_MIGRATIONS.map { it.startVersion to it.endVersion },
         )
     }


### PR DESCRIPTION
## Summary
- add shipped common categories and subcategories with schema migration support
- update category, categorization, and daily usage flows to use the common catalog and icon/color presentation
- add ignore confirmations as bottom sheets and keep Daily Usage content mounted behind a loading overlay

## Testing
- JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-17.jdk/Contents/Home ./gradlew :composeApp:compileDebugKotlinAndroid

## Notes
- The current Compose icon pack does not expose `Rickshaw` and `PropaneTank`, so those catalog keys resolve to existing material icons to keep the app compiling.